### PR TITLE
fix(go): indexed property access incorrectly renamed

### DIFF
--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -497,10 +497,11 @@ export class GoVisitor extends DefaultVisitor<GoLanguageContext> {
       valueSymbol.valueDeclaration != null &&
       ts.isMethodDeclaration(valueSymbol.valueDeclaration);
 
-    // When the expression has an unknown type (unresolved symbol), and has an upper-case first
-    // letter, we assume it's a type name... In such cases, what comes after can be considered a
-    // static member access. Note that the expression might be further qualified, so we check using
-    // a regex that checks for the last "."-delimited segment if there's dots in there...
+    // When the expression has an unknown type (unresolved symbol), has an upper-case first letter,
+    // and doesn't end in a call expression (as hinted by the presence of parentheses), we assume
+    // it's a type name... In such cases, what comes after can be considered a static member access.
+    // Note that the expression might be further qualified, so we check using a regex that checks
+    // for the last "." - delimited segment if there's dots in there...
     const expressionLooksLikeTypeReference =
       expressionType.symbol == null &&
       /(?:\.|^)[A-Z][^.)]*$/.exec(node.expression.getText(node.expression.getSourceFile())) != null;

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -48,7 +48,9 @@ export class Translator {
   public constructor(private readonly includeCompilerDiagnostics: boolean) {}
 
   public translate(snip: TypeScriptSnippet, languages: readonly TargetLanguage[] = Object.values(TargetLanguage)) {
-    logging.debug(`Translating ${snippetKey(snip)} ${inspect(snip.parameters ?? {})}`);
+    const key = snippetKey(snip);
+
+    logging.debug(`Translating ${key} ${inspect(snip.parameters ?? {})}`);
     const translator = this.translatorFor(snip);
 
     const translations = mkDict(
@@ -58,6 +60,9 @@ export class Translator {
           return [];
         }
         const languageConverterFactory = TARGET_LANGUAGES[lang];
+        if (key === 'f30b9ce840cff1a59ae7e630b7918179e732389ab9b773d94113037e2a2d3ff6' && lang === TargetLanguage.GO) {
+          debugger;
+        }
         const translated = translator.renderUsing(languageConverterFactory.createVisitor());
         return [[lang, { source: translated, version: languageConverterFactory.version }] as const];
       }),

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -48,9 +48,7 @@ export class Translator {
   public constructor(private readonly includeCompilerDiagnostics: boolean) {}
 
   public translate(snip: TypeScriptSnippet, languages: readonly TargetLanguage[] = Object.values(TargetLanguage)) {
-    const key = snippetKey(snip);
-
-    logging.debug(`Translating ${key} ${inspect(snip.parameters ?? {})}`);
+    logging.debug(`Translating ${snippetKey(snip)} ${inspect(snip.parameters ?? {})}`);
     const translator = this.translatorFor(snip);
 
     const translations = mkDict(
@@ -60,9 +58,6 @@ export class Translator {
           return [];
         }
         const languageConverterFactory = TARGET_LANGUAGES[lang];
-        if (key === 'f30b9ce840cff1a59ae7e630b7918179e732389ab9b773d94113037e2a2d3ff6' && lang === TargetLanguage.GO) {
-          debugger;
-        }
         const translated = translator.renderUsing(languageConverterFactory.createVisitor());
         return [[lang, { source: translated, version: languageConverterFactory.version }] as const];
       }),

--- a/test/translations/expressions/property_access.cs
+++ b/test/translations/expressions/property_access.cs
@@ -1,0 +1,2 @@
+object.PropertyA;
+object.PropertyB;

--- a/test/translations/expressions/property_access.go
+++ b/test/translations/expressions/property_access.go
@@ -1,0 +1,2 @@
+object.propertyA
+object.propertyB

--- a/test/translations/expressions/property_access.java
+++ b/test/translations/expressions/property_access.java
@@ -1,0 +1,2 @@
+object.getPropertyA();
+object.getPropertyB();

--- a/test/translations/expressions/property_access.py
+++ b/test/translations/expressions/property_access.py
@@ -1,0 +1,2 @@
+object.property_a
+object.property_b

--- a/test/translations/expressions/property_access.ts
+++ b/test/translations/expressions/property_access.ts
@@ -1,0 +1,6 @@
+///!hide
+declare const object: { [key: string]: unknown; };
+///!show
+
+object.propertyA;
+object.propertyB;


### PR DESCRIPTION
Go caches translated names for identifiers on the value symbol, however TypeScript since 3.9 changed how indexed property accesses are represented and uses a single symbol for all accesses through an index signature, causing the cache to incorrectly map all indexed accesses to the name of the very first one.

Fixes this issue by not using the symbol as a cache key when it corresponds to a transient signature.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0