### PR TITLE
chore: fixup dependencies on `commonmark` and `@jsii/check-node`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
     "ts-node": "^10.9.1"
   },
   "dependencies": {
-    "@jsii/check-node": "^1.76.0",
+    "@jsii/check-node": "1.76.0",
     "@jsii/spec": "^1.76.0",
     "@xmldom/xmldom": "^0.8.6",
-    "commonmark": "*",
+    "commonmark": "^0.30.0",
     "fast-glob": "^3.2.12",
     "jsii": "v4.9-next",
     "semver": "^7.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,7 +651,7 @@
     chalk "^4.1.2"
     semver "^7.3.8"
 
-"@jsii/check-node@^1.76.0":
+"@jsii/check-node@1.76.0":
   version "1.76.0"
   resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.76.0.tgz#3fcb41e916ae8bfba1fca0cbdc406fe0e0b2c7f5"
   integrity sha512-iAQohlms0FQNtmAsXOV9Rrd7QDikkLw68R2TPwhlVKuLPdHPKIK3gyeN0jqZzc0luNQ9h+3P7kSqfpKd+Kr79Q==
@@ -1785,7 +1785,7 @@ comment-json@4.2.2:
     has-own-prop "^2.0.0"
     repeat-string "^1.6.1"
 
-commonmark@*:
+commonmark@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.30.0.tgz#38811dc7bbf0f59d277ae09054d4d73a332f2e45"
   integrity sha512-j1yoUo4gxPND1JWV9xj5ELih0yMv1iCWDG6eEQIPLSWLxzCXiFoyS7kvB+WwU+tZMf4snwJMMtaubV0laFpiBA==


### PR DESCRIPTION
`commonmark` was mistakenly declared as `*`, which is too broad and risks cuasing runtime issues, and `@jsii/check-node` was using a caret dependency, which would lead to mis-representing what versions a release had been tested against.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0