### PR TITLE
fix: exampleDependencies aren't used

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mock-fs": "^5.2.0",
     "npm-check-updates": "^16",
     "prettier": "^2.8.7",
-    "projen": "^0.71.9",
+    "projen": "^0.71.11",
     "tar": "^6.1.13",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1"

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -165,6 +165,7 @@ export async function extractSnippets(
     const startTime = Date.now();
 
     const result = await translator.translateAll(snippets, {
+      compilationDirectory: options.compilationDirectory,
       cleanup: options.cleanup,
     });
 

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -92,6 +92,13 @@ export interface ExtractOptions {
    * @default false
    */
   readonly compressCacheToFile?: boolean;
+
+  /**
+   * Cleanup temporary directories
+   *
+   * @default true
+   */
+  readonly cleanup?: boolean;
 }
 
 export async function extractAndInfuse(assemblyLocations: string[], options: ExtractOptions): Promise<ExtractResult> {
@@ -157,7 +164,9 @@ export async function extractSnippets(
     logging.info('Translating');
     const startTime = Date.now();
 
-    const result = await translator.translateAll(snippets);
+    const result = await translator.translateAll(snippets, {
+      cleanup: options.cleanup,
+    });
 
     const delta = (Date.now() - startTime) / 1000;
     logging.info(

--- a/src/jsii/assemblies.ts
+++ b/src/jsii/assemblies.ts
@@ -18,7 +18,7 @@ import {
 import { resolveDependenciesFromPackageJson } from '../snippet-dependencies';
 import { enforcesStrictMode } from '../strict';
 import { LanguageTablet, DEFAULT_TABLET_NAME, DEFAULT_TABLET_NAME_COMPRESSED } from '../tablets/tablets';
-import { fmap, mkDict, sortBy } from '../util';
+import { fmap, mkDict, pathExists, sortBy } from '../util';
 
 /**
  * The JSDoc tag users can use to associate non-visible metadata with an example
@@ -347,10 +347,12 @@ function withProjectDirectory(dir: string, snippet: TypeScriptSnippet) {
 async function withDependencies(asm: LoadedAssembly, snippet: TypeScriptSnippet): Promise<TypeScriptSnippet> {
   const compilationDependencies: Record<string, CompilationDependency> = {};
 
-  compilationDependencies[asm.assembly.name] = {
-    type: 'concrete',
-    resolvedDirectory: await fsPromises.realpath(asm.directory),
-  };
+  if (await pathExists(path.join(asm.directory, 'package.json'))) {
+    compilationDependencies[asm.assembly.name] = {
+      type: 'concrete',
+      resolvedDirectory: await fsPromises.realpath(asm.directory),
+    };
+  }
 
   Object.assign(compilationDependencies, await resolveDependenciesFromPackageJson(asm.packageJson, asm.directory));
 

--- a/src/jsii/assemblies.ts
+++ b/src/jsii/assemblies.ts
@@ -341,7 +341,8 @@ function withProjectDirectory(dir: string, snippet: TypeScriptSnippet) {
  * The dependencies will be taken from the package.json, and will consist of:
  *
  * - The package itself
- * - The package's dependencies and peerDependencies
+ * - The package's dependencies and peerDependencies (but NOT devDependencies). Will
+ *   symlink to the files on disk.
  * - Any additional dependencies declared in `jsiiRosetta.exampleDependencies`.
  */
 async function withDependencies(asm: LoadedAssembly, snippet: TypeScriptSnippet): Promise<TypeScriptSnippet> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -243,6 +243,11 @@ async function main() {
             describe: 'Compress the cache-to file',
             default: false,
           })
+          .options('cleanup', {
+            type: 'boolean',
+            describe: 'Clean up temporary directories',
+            default: true,
+          })
           .conflicts('loose', 'strict')
           .conflicts('loose', 'fail'),
       wrapHandler(async (args) => {
@@ -269,6 +274,7 @@ async function main() {
           loose: args.loose,
           compressTablet: args['compress-tablet'],
           compressCacheToFile: args['compress-cache'],
+          cleanup: args.cleanup,
         };
 
         const result = args.infuse

--- a/src/rosetta-translator.ts
+++ b/src/rosetta-translator.ts
@@ -190,7 +190,11 @@ export class RosettaTranslator {
     } finally {
       process.chdir(origDir);
       if (cleanCompilationDir) {
-        await fs.rm(compilationDirectory, { force: true, recursive: true });
+        if (options.cleanup ?? true) {
+          await fs.rm(compilationDirectory, { force: true, recursive: true });
+        } else {
+          logging.info(`Leaving directory uncleaned: ${compilationDirectory}`);
+        }
       }
     }
 
@@ -309,4 +313,9 @@ export interface TranslateAllOptions {
    * @default true
    */
   readonly addToTablet?: boolean;
+
+  /**
+   * @default true
+   */
+  readonly cleanup?: boolean;
 }

--- a/src/rosetta-translator.ts
+++ b/src/rosetta-translator.ts
@@ -5,7 +5,12 @@ import { TypeFingerprinter } from './jsii/fingerprinting';
 import { TARGET_LANGUAGES } from './languages';
 import * as logging from './logging';
 import { TypeScriptSnippet, completeSource } from './snippet';
-import { collectDependencies, validateAvailableDependencies, prepareDependencyDirectory } from './snippet-dependencies';
+import {
+  collectDependencies,
+  validateAvailableDependencies,
+  prepareDependencyDirectory,
+  expandWithTransitiveDependencies,
+} from './snippet-dependencies';
 import { snippetKey } from './tablets/key';
 import { LanguageTablet, TranslatedSnippet } from './tablets/tablets';
 import { translateAll, TranslateAllResult } from './translate_all';
@@ -168,6 +173,7 @@ export class RosettaTranslator {
         : { addToTablet: optionsOrAddToTablet };
 
     const exampleDependencies = collectDependencies(snippets);
+    await expandWithTransitiveDependencies(exampleDependencies);
 
     let compilationDirectory;
     let cleanCompilationDir = false;

--- a/src/snippet-dependencies.ts
+++ b/src/snippet-dependencies.ts
@@ -3,11 +3,12 @@ import { promises as fsPromises } from 'node:fs';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { PackageJson } from '@jsii/spec';
 import * as fastGlob from 'fast-glob';
 import * as semver from 'semver';
 import { intersect } from 'semver-intersect';
 
-import { findDependencyDirectory, findUp } from './find-utils';
+import { findDependencyDirectory, findUp, isBuiltinModule } from './find-utils';
 import * as logging from './logging';
 import { TypeScriptSnippet, CompilationDependency } from './snippet';
 import { mkDict, formatList, pathExists } from './util';
@@ -25,6 +26,66 @@ export function collectDependencies(snippets: TypeScriptSnippet[]) {
     }
   }
   return ret;
+}
+
+/**
+ * Add transitive dependencies of concrete dependencies to the array
+ *
+ * This is necessary to prevent multiple copies of transitive dependencies on disk, which
+ * jsii-based packages might not deal with very well.
+ */
+export async function expandWithTransitiveDependencies(deps: Record<string, CompilationDependency>) {
+  const pathsSeen = new Set<string>();
+  const queue = Object.values(deps).filter(isConcrete);
+
+  let next = queue.shift();
+  while (next) {
+    await addDependenciesOf(next.resolvedDirectory);
+    next = queue.shift();
+  }
+
+  async function addDependenciesOf(dir: string) {
+    if (pathsSeen.has(dir)) {
+      return;
+    }
+    pathsSeen.add(dir);
+    const pj: PackageJson = JSON.parse(
+      await fsPromises.readFile(path.join(dir, 'package.json'), { encoding: 'utf-8' }),
+    );
+
+    for (const [name, dep] of Object.entries(await resolveDependenciesFromPackageJson(pj, dir))) {
+      if (!deps[name]) {
+        deps[name] = dep;
+        queue.push(dep);
+      }
+    }
+  }
+}
+
+/**
+ * Find the corresponding package directories for all dependencies in a package.json
+ */
+export async function resolveDependenciesFromPackageJson(packageJson: PackageJson | undefined, directory: string) {
+  return mkDict(
+    await Promise.all(
+      Object.keys({ ...packageJson?.dependencies, ...packageJson?.peerDependencies })
+        .filter((name) => !isBuiltinModule(name))
+        .filter(
+          (name) =>
+            !packageJson?.bundledDependencies?.includes(name) && !packageJson?.bundleDependencies?.includes(name),
+        )
+        .map(
+          async (name) =>
+            [
+              name,
+              {
+                type: 'concrete',
+                resolvedDirectory: await fsPromises.realpath(await findDependencyDirectory(name, directory)),
+              },
+            ] as const,
+        ),
+    ),
+  );
 }
 
 function resolveConflict(
@@ -148,42 +209,38 @@ export async function prepareDependencyDirectory(deps: Record<string, Compilatio
     ]),
   );
 
-  // Use 'npm install' only for the symbolic packages. For the concrete packages,
-  // npm is going to try and find transitive dependencies as well and it won't know
-  // about monorepos.
-  const symbolicInstalls = Object.entries(resolvedDeps).flatMap(([name, dep]) =>
-    isSymbolic(dep) ? [`${name}@${dep.versionRange}`] : [],
-  );
-  const linkedInstalls = mkDict(
-    Object.entries(resolvedDeps).flatMap(([name, dep]) =>
-      isConcrete(dep) ? [[name, dep.resolvedDirectory] as const] : [],
+  const dependencies: Record<string, string> = {};
+  for (const [name, dep] of Object.entries(resolvedDeps)) {
+    if (isConcrete(dep)) {
+      logging.debug(`${name} -> ${dep.resolvedDirectory}`);
+      dependencies[name] = `file:${dep.resolvedDirectory}`;
+    } else {
+      logging.debug(`${name} @ ${dep.versionRange}`);
+      dependencies[name] = dep.versionRange;
+    }
+  }
+
+  await fsPromises.writeFile(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'examples',
+        version: '0.0.1',
+        private: true,
+        dependencies,
+      },
+      undefined,
+      2,
     ),
+    {
+      encoding: 'utf-8',
+    },
   );
 
-  // Run 'npm install' on it
-  if (symbolicInstalls.length > 0) {
-    logging.debug(`Installing example dependencies: ${symbolicInstalls.join(' ')}`);
-    cp.execSync(`npm install ${symbolicInstalls.join(' ')}`, { cwd: tmpDir, encoding: 'utf-8' });
-  }
-
-  // Symlink the rest
-  if (Object.keys(linkedInstalls).length > 0) {
-    logging.debug(`Symlinking example dependencies: ${Object.values(linkedInstalls).join(' ')}`);
-    const modDir = path.join(tmpDir, 'node_modules');
-    await Promise.all(
-      Object.entries(linkedInstalls).map(async ([name, source]) => {
-        const target = path.join(modDir, name);
-
-        // Any packages that may have been put there already by `npm install` -- replace 'em
-        // with the symlinks if necessary.
-        if (await pathExists(target)) {
-          await fsPromises.rm(target, { recursive: true, force: true });
-        }
-        await fsPromises.mkdir(path.dirname(target), { recursive: true });
-        await fsPromises.symlink(source, target, 'dir');
-      }),
-    );
-  }
+  // Run NPM install on this package.json. We need to include --force for packages
+  // that have a symbolic version in the symlinked dev tree (like "0.0.0"), but have
+  // actual version range dependencies from externally installed packages (like "^2.0.0").
+  cp.execSync(`npm install --force --loglevel error`, { cwd: tmpDir, encoding: 'utf-8' });
 
   return tmpDir;
 }
@@ -249,10 +306,6 @@ async function findMonoRepoGlobs(startingDir: string): Promise<Set<string>> {
   }
 
   return ret;
-}
-
-function isSymbolic(x: CompilationDependency): x is Extract<CompilationDependency, { type: 'symbolic' }> {
-  return x.type === 'symbolic';
 }
 
 function isConcrete(x: CompilationDependency): x is Extract<CompilationDependency, { type: 'concrete' }> {

--- a/src/snippet-dependencies.ts
+++ b/src/snippet-dependencies.ts
@@ -49,15 +49,21 @@ export async function expandWithTransitiveDependencies(deps: Record<string, Comp
       return;
     }
     pathsSeen.add(dir);
-    const pj: PackageJson = JSON.parse(
-      await fsPromises.readFile(path.join(dir, 'package.json'), { encoding: 'utf-8' }),
-    );
-
-    for (const [name, dep] of Object.entries(await resolveDependenciesFromPackageJson(pj, dir))) {
-      if (!deps[name]) {
-        deps[name] = dep;
-        queue.push(dep);
+    try {
+      const pj: PackageJson = JSON.parse(
+        await fsPromises.readFile(path.join(dir, 'package.json'), { encoding: 'utf-8' }),
+      );
+      for (const [name, dep] of Object.entries(await resolveDependenciesFromPackageJson(pj, dir))) {
+        if (!deps[name]) {
+          deps[name] = dep;
+          queue.push(dep);
+        }
       }
+    } catch (e: any) {
+      if (e.code === 'ENOENT') {
+        return;
+      }
+      throw e;
     }
   }
 }

--- a/src/snippet.ts
+++ b/src/snippet.ts
@@ -310,7 +310,8 @@ export enum SnippetParameters {
   /**
    * What directory to resolve fixtures in for this snippet (system parameter)
    *
-   * Attached during processing, should not be used by authors.
+   * Attached during processing, should not be used by authors. Does NOT imply
+   * anything about the directory where we pretend to compile this file.
    */
   $PROJECT_DIRECTORY = '$directory',
 

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -166,9 +166,7 @@ export class SnippetTranslator {
   public constructor(snippet: TypeScriptSnippet, private readonly options: SnippetTranslatorOptions = {}) {
     const compiler = options.compiler ?? new TypeScriptCompiler();
     const source = completeSource(snippet);
-    const fakeCurrentDirectory =
-      snippet.parameters?.[SnippetParameters.$COMPILATION_DIRECTORY] ??
-      snippet.parameters?.[SnippetParameters.$PROJECT_DIRECTORY];
+    const fakeCurrentDirectory = snippet.parameters?.[SnippetParameters.$COMPILATION_DIRECTORY] ?? process.cwd();
     this.compilation = compiler.compileInMemory(
       removeSlashes(formatLocation(snippet.location)),
       source,

--- a/test/commands/extract.test.ts
+++ b/test/commands/extract.test.ts
@@ -19,7 +19,8 @@ import * as logging from '../../lib/logging';
 import { pathExists } from '../../lib/util';
 import { TestJsiiModule, DUMMY_JSII_CONFIG, testSnippetLocation } from '../testutil';
 
-jest.setTimeout(30_000);
+// One of these tests needs to download aws-cdk-lib from the internet
+jest.setTimeout(60_000);
 
 const DUMMY_README = `
   Here is an example of how to use ClassA:

--- a/test/commands/extract.test.ts
+++ b/test/commands/extract.test.ts
@@ -19,8 +19,8 @@ import * as logging from '../../lib/logging';
 import { pathExists } from '../../lib/util';
 import { TestJsiiModule, DUMMY_JSII_CONFIG, testSnippetLocation } from '../testutil';
 
-// One of these tests needs to download aws-cdk-lib from the internet
-jest.setTimeout(60_000);
+// One of these tests needs to download aws-cdk-lib from the internet, ample time
+jest.setTimeout(120_000);
 
 const DUMMY_README = `
   Here is an example of how to use ClassA:

--- a/test/commands/extract.test.ts
+++ b/test/commands/extract.test.ts
@@ -807,6 +807,54 @@ test('infused examples have no diagnostics', async () => {
   }
 });
 
+test('example can successfully use a jsii package from the interwebs', async () => {
+  // GIVEN
+  const otherAssembly = TestJsiiModule.fromSource(
+    {
+      'index.ts': `
+      /**
+       * ClassA
+       *
+       * @example
+       * import { Construct } from 'constructs';
+       * import { SampleRepository } from 'construct-hub-probe';
+       *
+       * declare const stack: Construct;
+       *
+       * new SampleRepository(stack, 'Repo', { name: 'hiii' });
+       */
+      export class ClassA {
+        public someMethod() {
+        }
+      }
+      `,
+    },
+    {
+      name: 'my_assembly',
+      jsii: {
+        ...DUMMY_JSII_CONFIG,
+      },
+      jsiiRosetta: {
+        exampleDependencies: {
+          'construct-hub-probe': '*',
+        },
+      },
+    },
+  );
+  try {
+    // WHEN
+    const results = await extract.extractSnippets([otherAssembly.moduleDirectory], {
+      includeCompilerDiagnostics: true,
+      loose: false,
+    });
+
+    // THEN
+    expect(results.diagnostics).toEqual([]);
+  } finally {
+    otherAssembly.cleanup();
+  }
+});
+
 class MockTranslator extends RosettaTranslator {
   public constructor(opts: RosettaTranslatorOptions, translatorFn: jest.Mock) {
     super(opts);

--- a/test/commands/extract.test.ts
+++ b/test/commands/extract.test.ts
@@ -837,6 +837,10 @@ test('example can successfully use a jsii package from the interwebs', async () 
       jsiiRosetta: {
         exampleDependencies: {
           'construct-hub-probe': '*',
+          // These strictly speaking shouldn't need to be here, but guard against testing
+          // with an old NPM version
+          'aws-cdk-lib': '^2.75.0',
+          'constructs': '^10.2.0',
         },
       },
     },

--- a/test/commands/trim-cache.test.ts
+++ b/test/commands/trim-cache.test.ts
@@ -11,6 +11,8 @@ import { extractSnippets } from '../../lib/commands/extract';
 import { trimCache } from '../../lib/commands/trim-cache';
 import { TestJsiiModule, DUMMY_JSII_CONFIG, testSnippetLocation } from '../testutil';
 
+jest.setTimeout(30_000);
+
 const DUMMY_README = `
   Here is an example of how to use ClassA:
 

--- a/test/jsii/assemblies.test.ts
+++ b/test/jsii/assemblies.test.ts
@@ -8,6 +8,8 @@ import { allTypeScriptSnippets } from '../../lib/jsii/assemblies';
 import { SnippetParameters } from '../../lib/snippet';
 import { TestJsiiModule, DUMMY_JSII_CONFIG } from '../testutil';
 
+jest.setTimeout(30_000);
+
 test('Extract snippet from README', async () => {
   const snippets = Array.from(
     await allTypeScriptSnippets([

--- a/test/testutil.ts
+++ b/test/testutil.ts
@@ -129,5 +129,5 @@ export const DUMMY_JSII_CONFIG = {
 
 export async function withTemporaryDirectory<T>(callback: (dir: string) => Promise<T>): Promise<T> {
   const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), path.basename(__filename)));
-  return callback(tmpdir).finally(() => fs.rmSync(tmpdir, { recursive: true }));
+  return callback(path.resolve(tmpdir)).finally(() => fs.rmSync(tmpdir, { recursive: true }));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,9 +1677,9 @@ camelcase@^7.0.0:
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
 
 caniuse-lite@^1.0.30001449:
-  version "1.0.30001478"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001478.tgz#0ef8a1cf8b16be47a0f9fc4ecfc952232724b32a"
-  integrity sha512-gMhDyXGItTHipJj2ApIvR+iVB5hd0KP3svMWWXDvZOmjzJJassGLMfxRkQCSYgGd2gtdL/ReeiyvMSFD1Ss6Mw==
+  version "1.0.30001479"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001479.tgz#ef3d6f76011e44181af411fd4896123afbc14eda"
+  integrity sha512-6nuRFim5dx8Eu2tO+KJ9PiBdPHs7WB5Hdf+klDcyefyEuOAcfhihIv7pS+JFknJLUiNQbm1AJYKm0c9QOlQS/Q==
 
 case@^1.6.3:
   version "1.6.3"
@@ -4593,10 +4593,10 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.71.9:
-  version "0.71.9"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.71.9.tgz#da732db618a3890ab933086c81c3193492c87a6e"
-  integrity sha512-iUFEus6eTHg91fG6A1ABTN0rvgYspkfhY1SBKYfP2A0bIYN5NNC4F++5TADmfWTSYAu4UbqL7Nyx5feUFnsuCA==
+projen@^0.71.11:
+  version "0.71.11"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.71.11.tgz#0e7da256ef6dca8221e56c369b03440f0c413522"
+  integrity sha512-ANIR8VNsFnqDI3yIMtMHPquD+U9K1gldTw8gnzfFcWCb1sy6u2o3+Cr50hMZBEDYiBGV3k922ejMOB5yp5GDCg==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"
@@ -4606,7 +4606,7 @@ projen@^0.71.9:
     fast-json-patch "^3.1.1"
     glob "^8"
     ini "^2.0.0"
-    semver "^7.3.8"
+    semver "^7.4.0"
     shx "^0.3.4"
     xmlbuilder2 "^2.4.1"
     yaml "2.0.0"
@@ -4752,9 +4752,9 @@ rechoir@^0.6.2:
     resolve "^1.1.6"
 
 regexp-tree@^0.1.24, regexp-tree@~0.1.1:
-  version "0.1.24"
-  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.24.tgz#3d6fa238450a4d66e5bc9c4c14bb720e2196829d"
-  integrity sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==
+  version "0.1.25"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.25.tgz#1c864b07c06a198fc8153ddbe047897a5547305e"
+  integrity sha512-szcL3aqw+vEeuxhL1AMYRyeMP+goYF5I/guaH10uJX5xbGyeQeNPPneaj3ZWVmGLCDxrVaaYekkr5R12gk4dJw==
 
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
@@ -5499,9 +5499,9 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 typescript@next:
-  version "5.1.0-dev.20230415"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.0-dev.20230415.tgz#c8af4210a03ac8f67585481456023a098cd3492b"
-  integrity sha512-YZh1oFbd4auqDxLtuxuC41IVTBJNiqnbQVkjR5Z/hWBJZkHj5GRiBa+0F5lW6LdVzdE326Q530h/p7NsbN50+A==
+  version "5.1.0-dev.20230416"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.0-dev.20230416.tgz#20d4b5021523e7d79fb00df4163399ea0ef778c2"
+  integrity sha512-LdNpnAyqzCIcx7R5/cZDGlsxGTL4j+omGMhMYVCVaroMOFZBnMtzUJSlMIO9yHBjN5ENSVJ2+Pq57GwmSPiZFA==
 
 typescript@~5.0.4:
   version "5.0.4"


### PR DESCRIPTION
Rosetta has a feature to include external packages into its example compilation dependency tree, so that you can write examples in your README using packages that depend on the package you're writing the README for. You couldn't have those dependencies in your actual dependency tree, but there is a special section in `package.json` that can do it.

Schematically:

```
  mydep                          
    ▲                            
    │                            
mypackage   < write a compilable example that uses 'myinteg'
    ▲ 
    │                            
myinteg                          
```

Put the following into `package.json`:

```json
{
  "jsiiRosetta": {
    "exampleDependencies": {
      "myinteg": "^1.2.3"
    }
  }
}
```

While this feature was advertised, it didn't actually work:

* The dependency closure tree was built, but it was never used during compilation (we erroneously set the compilation directory to the directory of the package the sample was found).
* You could not specify `*` as a version number because a package we use, `semver-intersect`, doesn't support `*`.
* We need to take additional care when mixing symlinked and installed packages that `peerDependency` (e.g., `constructs`). By the original closure directory construction method, we would end up with the wrong version of `aws-cdk-lib` in the dependency closure, and 2 copies of `constructs` (leading to the `Construct is not assignable to Construct` error).

To solve all of this, fully crawl the dependency tree, build a `package.json` to install everything in one go, and do use the compilation directory that we build this way.

Also in this PR:

* Wrap `semver-intersect` with a helper function to handle one more case and fail gracefully if we encounter more cases it doesn't handle.
* Add some debug printing and a `--no-cleanup` flag for easier debugging.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0