### PR TITLE
fix: allow prereleases for `*`

### DIFF
--- a/src/snippet-dependencies.ts
+++ b/src/snippet-dependencies.ts
@@ -123,7 +123,7 @@ function resolveConflict(
       fs.readFileSync(path.join(a.resolvedDirectory, 'package.json'), 'utf-8'),
     ).version;
 
-    if (!semver.satisfies(concreteVersion, b.versionRange)) {
+    if (!semver.satisfies(concreteVersion, b.versionRange, { includePrerelease: true })) {
       throw new Error(
         `Dependency conflict: ${name} expected to match ${b.versionRange} but found ${concreteVersion} at ${a.resolvedDirectory}`,
       );


### PR DESCRIPTION

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0