### PR TITLE
fix: export transliterateAssembly and fix bug with transliterate cli

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,5 @@ export * from './rosetta-reader';
 export * from './rosetta-translator';
 export * from './snippet';
 export * from './markdown';
+export * from './commands/transliterate';
 export * from './strict';

--- a/src/main.ts
+++ b/src/main.ts
@@ -297,7 +297,6 @@ async function main() {
             describe: 'Assembly to transliterate',
           })
           .option('language', {
-            alias: 'l',
             type: 'string',
             array: true,
             default: [],
@@ -328,15 +327,17 @@ async function main() {
         );
         const languages =
           args.language.length > 0
-            ? args.language.map((lang) => {
-                const target = Object.entries(TargetLanguage).find(([k]) => k === lang)?.[1];
-                if (target == null) {
-                  throw new Error(
-                    `Unknown target language: ${lang}. Expected one of ${Object.keys(TargetLanguage).join(', ')}`,
-                  );
-                }
-                return target;
-              })
+            ? args.language
+                .map((lang) => lang.toUpperCase())
+                .map((lang) => {
+                  const target = Object.entries(TargetLanguage).find(([k]) => k === lang)?.[1];
+                  if (target == null) {
+                    throw new Error(
+                      `Unknown target language: ${lang}. Expected one of ${Object.keys(TargetLanguage).join(', ')}`,
+                    );
+                  }
+                  return target;
+                })
             : Object.values(TargetLanguage);
         return transliterateAssembly(assemblies, languages, args);
       }),


### PR DESCRIPTION
This function is already used in other tools and should be available as programmatic API.

Both `--loose` and `--language` were using the `-l` alias, causing the language option to be booleans instead of strings.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0