### PR TITLE
chore: upgrade workflow fails on install:ci

### DIFF
--- a/.github/workflows/upgrade-maintenance-v5.0.yml
+++ b/.github/workflows/upgrade-maintenance-v5.0.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Back-port projenrc changes from main
         env:
           CI: "true"
-        run: git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen
+        run: git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen install
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations

--- a/.github/workflows/upgrade-maintenance-v5.0.yml
+++ b/.github/workflows/upgrade-maintenance-v5.0.yml
@@ -26,8 +26,8 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: Back-port projenrc changes from main
         env:
-          CI: "true"
-        run: git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen install
+          CI: "false"
+        run: git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations

--- a/projenrc/upgrade-dependencies.ts
+++ b/projenrc/upgrade-dependencies.ts
@@ -274,9 +274,13 @@ export class UpgradeDependencies extends Component {
       ...(branch && branch !== 'main'
         ? [
             {
-              env: { CI: 'true' },
+              env: {
+                // Important: this ensures `yarn projen` runs `yarn install` and not `yarn install:ci` so it can update
+                // the yarn.lock file.
+                CI: 'false',
+              },
               name: 'Back-port projenrc changes from main',
-              run: 'git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen install',
+              run: 'git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen',
             },
           ]
         : []),

--- a/projenrc/upgrade-dependencies.ts
+++ b/projenrc/upgrade-dependencies.ts
@@ -276,7 +276,7 @@ export class UpgradeDependencies extends Component {
             {
               env: { CI: 'true' },
               name: 'Back-port projenrc changes from main',
-              run: 'git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen',
+              run: 'git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen install',
             },
           ]
         : []),


### PR DESCRIPTION
Set `CI=false` in the back-porting environment so that `yarn projen` runs the `install` task instead of the `install:ci` task (which prevents lockfile updates).


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0