### PR TITLE
fix: import jsii submodule

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -136,7 +136,7 @@
     },
     {
       "name": "jsii",
-      "version": "5.1.x",
+      "version": "~5.1.5",
       "type": "runtime"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -5,6 +5,10 @@ import { ReleaseWorkflow } from './projenrc/release';
 import { SUPPORT_POLICY, SupportPolicy } from './projenrc/support';
 import { UpgradeDependencies } from './projenrc/upgrade-dependencies';
 
+// This should be '0' for new version lines
+// However it might be required to depend on a version with a specific feature or bug-fix
+const JSII_PATCH_VERSION = '5';
+
 const project = new typescript.TypeScriptProject({
   projenrcTs: true,
 
@@ -35,6 +39,7 @@ const project = new typescript.TypeScriptProject({
       // @see https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
       lib: ['es2020', 'es2021.WeakRef'],
       target: 'ES2020',
+      moduleResolution: javascript.TypeScriptModuleResolution.NODE16,
 
       esModuleInterop: false,
       noImplicitOverride: true,
@@ -108,7 +113,7 @@ const project = new typescript.TypeScriptProject({
     'chalk@^4',
     'commonmark',
     'fast-glob',
-    `jsii@${versionMajorMinor}.x`,
+    `jsii@~${versionMajorMinor}.${JSII_PATCH_VERSION}`,
     'semver-intersect',
     'semver',
     'stream-json',

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mock-fs": "^5.2.0",
     "npm-check-updates": "^16",
     "prettier": "^2.8.8",
-    "projen": "^0.71.124",
+    "projen": "^0.71.125",
     "tar": "^6.1.15",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1"
@@ -66,7 +66,7 @@
     "chalk": "^4",
     "commonmark": "^0.30.0",
     "fast-glob": "^3.3.0",
-    "jsii": "5.1.x",
+    "jsii": "~5.1.5",
     "semver": "^7.5.3",
     "semver-intersect": "^1.4.0",
     "stream-json": "^1.8.0",

--- a/src/jsii/jsii-utils.ts
+++ b/src/jsii/jsii-utils.ts
@@ -1,5 +1,5 @@
 import * as spec from '@jsii/spec';
-import { symbolIdentifier } from 'jsii';
+import { symbolIdentifier } from 'jsii/common';
 import * as ts from 'typescript';
 
 import { findTypeLookupAssembly, TypeLookupAssembly } from './assemblies';

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -25,6 +25,7 @@
     "strictPropertyInitialization": true,
     "stripInternal": true,
     "target": "ES2020",
+    "moduleResolution": "node16",
     "noImplicitOverride": true,
     "skipLibCheck": true,
     "sourceMap": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     "strictPropertyInitialization": true,
     "stripInternal": true,
     "target": "ES2020",
+    "moduleResolution": "node16",
     "noImplicitOverride": true,
     "skipLibCheck": true,
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,9 +1266,9 @@ acorn-walk@^8.1.1:
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
 acorn@^8.4.1, acorn@^8.9.0:
-  version "8.9.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.9.0.tgz#78a16e3b2bcc198c10822786fa6679e245db5b59"
-  integrity sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -3748,10 +3748,10 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
-jsii@5.1.x:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.1.4.tgz#cc6bcbed91a337fd61d82f665a2cf4a3e1184da0"
-  integrity sha512-c5AU0Af/uNtY3exSpR1qnhRG6c9YZWgjkhQcVGyz58lcd9L245DIk0gQ13QAaBpVyFm5VYQrhPCm4k8QZSvsug==
+jsii@~5.1.5:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.1.5.tgz#ef526a96b28a847a87e66169963a3c209807aa0d"
+  integrity sha512-21y6Jz5F1gK6JwEIndiimRO4NqF9sc8AuDLHXJW5XKq2LSxiHsdqrNW+W/w8smITPX6GlWNFuznWJjPJUMrd8w==
   dependencies:
     "@jsii/check-node" "1.84.0"
     "@jsii/spec" "^1.84.0"
@@ -4634,10 +4634,10 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.71.124:
-  version "0.71.124"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.71.124.tgz#94823d7af5842f0ca6692f9f2464d90edfd525d0"
-  integrity sha512-XSS+A46RyP140kBfIewMO8Qym2g2o5/F+ntIQZ3kSsGe2vTEvUk63LauqkMzIv2StTwCv/6veRjIriXmdEwsMg==
+projen@^0.71.125:
+  version "0.71.125"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.71.125.tgz#d7699a52ddc8a002d76ee4c2024bfeb4bd9116e6"
+  integrity sha512-PE9qfv+6r7aFsA+N/daZXHeSkIW7PjGEUsCq33JlxRU4P2d7N+j9hg1HrCzB/T2PSoflPuxjG40kjGfnbFB+3A==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"
@@ -5553,9 +5553,9 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 typescript@next:
-  version "5.2.0-dev.20230704"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.0-dev.20230704.tgz#1e372df09af8a1d6d67f6ecb522d5bc06c507ebe"
-  integrity sha512-LAjnbCofaVoQt8mhUODn7xG2uHBTxIDPsxJ9iowOKcbOe1GJIpNqyvEvNrkvmf0pIRHiC19f6oGSYrilB9s5ng==
+  version "5.2.0-dev.20230705"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.0-dev.20230705.tgz#a793c11eef3a867de2c31484b4f89c8aaabdd31f"
+  integrity sha512-eMgfQ/e5CgYYSaduGhDc2UiY2EzzgrBMfHyagjUP70jj4VDCmLlIp1EftT5AMiLvNc7PYNCeziRFY5fBZhD9uA==
 
 typescript@~5.1.6:
   version "5.1.6"


### PR DESCRIPTION
Using the `common` submodule directly avoids bundling all of jsii.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0