### PR TITLE
chore: set latest flag on GitHub releases explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,12 +102,12 @@ jobs:
         if: "!fromJSON(steps.release-exists.outputs.result) && fromJSON(needs.build.outputs.prerelease)"
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create ${{ github.ref_name }} --repo=${{ github.repository }} --generate-notes --title=${{ github.ref_name }} --verify-tag --prerelease
+        run: gh release create ${{ github.ref_name }} --repo=${{ github.repository }} --generate-notes --title=${{ github.ref_name }} --verify-tag --prerelease --latest=${{ needs.build.outputs.latest }}
       - name: Create Release
         if: "!fromJSON(steps.release-exists.outputs.result) && !fromJSON(needs.build.outputs.prerelease)"
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create ${{ github.ref_name }} --repo=${{ github.repository }} --generate-notes --title=${{ github.ref_name }} --verify-tag
+        run: gh release create ${{ github.ref_name }} --repo=${{ github.repository }} --generate-notes --title=${{ github.ref_name }} --verify-tag --latest=${{ needs.build.outputs.latest }}
       - name: Attach assets
         env:
           GH_TOKEN: ${{ github.token }}

--- a/projenrc/release.ts
+++ b/projenrc/release.ts
@@ -159,6 +159,7 @@ export class ReleaseWorkflow {
             '--title=${{ github.ref_name }}',
             '--verify-tag',
             '--prerelease',
+            `--latest=\${{ needs.build.outputs.${PublishTargetOutput.IS_LATEST} }}`,
           ].join(' '),
           env: {
             GH_TOKEN: '${{ github.token }}',
@@ -173,6 +174,7 @@ export class ReleaseWorkflow {
             '--generate-notes',
             '--title=${{ github.ref_name }}',
             '--verify-tag',
+            `--latest=\${{ needs.build.outputs.${PublishTargetOutput.IS_LATEST} }}`,
           ].join(' '),
           env: {
             GH_TOKEN: '${{ github.token }}',


### PR DESCRIPTION
Otherwise, the latest-dated release will be considered "the" latest, while we want this to only apply to the release that is tagged as "latest" on npm as well.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0