### PR TITLE
chore(projenrc): Pass Dependency Types to node package

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -232,7 +232,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade"
+          "exec": "yarn upgrade @actions/core @actions/github @types/commonmark @types/jest @types/mock-fs @types/node @types/stream-json @types/tar @types/workerpool @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint-plugin-unicorn eslint jest mock-fs npm-check-updates prettier projen tar ts-jest ts-node @jsii/check-node @jsii/spec @xmldom/xmldom chalk commonmark fast-glob jsii semver semver-intersect stream-json typescript workerpool yargs"
         },
         {
           "exec": "npx projen"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mock-fs": "^5.2.0",
     "npm-check-updates": "^16",
     "prettier": "^2.8.8",
-    "projen": "^0.71.156",
+    "projen": "^0.71.159",
     "tar": "^6.1.15",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1"

--- a/projenrc/upgrade-dependencies.ts
+++ b/projenrc/upgrade-dependencies.ts
@@ -190,8 +190,9 @@ export class UpgradeDependencies extends Component {
     // update npm-check-updates before everything else, in case there is a bug
     // in it or one of its dependencies. This will make upgrade workflows
     // slightly more stable and resilient to upstream changes.
+    const depTypes = this.project.deps.all.map((dep) => dep.type);
     steps.push({
-      exec: this._project.package.renderUpgradePackagesCommand([], ['npm-check-updates']),
+      exec: this._project.package.renderUpgradePackagesCommand(depTypes, [], ['npm-check-updates']),
     });
 
     for (const dep of ['dev', 'optional', 'peer', 'prod', 'bundle']) {
@@ -223,7 +224,7 @@ export class UpgradeDependencies extends Component {
 
     // run upgrade command to upgrade transitive deps as well
     steps.push({
-      exec: this._project.package.renderUpgradePackagesCommand(exclude, this.options.include),
+      exec: this._project.package.renderUpgradePackagesCommand(depTypes, exclude, this.options.include),
     });
 
     // run "projen" to give projen a chance to update dependencies (it will also run "yarn install")

--- a/yarn.lock
+++ b/yarn.lock
@@ -4676,10 +4676,10 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.71.156:
-  version "0.71.156"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.71.156.tgz#ccabe219df4be76176dd8228d3b741883007e207"
-  integrity sha512-tMZrT65pfX4YSUWBWM+N4To+TxfJ2Pd62m2Q/HqSY7lAJnXNoGD9xnPUEwLc/oZRU2DN6C2F1JFgKzDRhs5MqA==
+projen@^0.71.159:
+  version "0.71.159"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.71.159.tgz#f68738f0efe41953b1737dbc36f99936001a5528"
+  integrity sha512-PpoOqe4Gx2AAJaEfFa3NpFveBqr8aUsWkymkhN8IjplrMYjePCzIMPT+z/vkQuj6J0u8+Uq1OhpQRbStSMi8JA==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
https://github.com/projen/projen/pull/2835 added a new argument to renderUpgradePackages(), types, which is now the first argument of the function. Anything that calls renderUpgradePackages() now needs to specify types in front.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0