### PR TITLE
chore: mockfs broken on node v20.5+

### DIFF
--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -51,7 +51,7 @@ function loadLiterateSource(directory: string, literateFileName: string) {
     // This couldn't really happen in practice, but do the check anyway
     throw new Error(`Sample uses literate source ${literateFileName}, but not found: ${fullPath}`);
   }
-  return fs.readFileSync(fullPath, { encoding: 'utf-8' });
+  return fs.readFileSync(fullPath).toString('utf-8');
 }
 
 /**


### PR DESCRIPTION
Implementing the workaround mentioned in the linked issue. The only downside of this change is losing out on the performance improvements in v20.5.

re https://github.com/tschaub/mock-fs/issues/377



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0