### PR TITLE
fix: JSII_ROSETTA_MAX_WORKER_COUNT is not respected when higher than 50% of cores

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16.x
           - 18.x
           - 20.x
   matrix-clear:

--- a/src/translate_all.ts
+++ b/src/translate_all.ts
@@ -26,8 +26,9 @@ export async function translateAll(
   // help that much, or we become I/O-bound at some point. On my machine, using
   // more than half the cores actually makes it slower.
   // Cap to a reasonable top-level limit to prevent thrash on machines with many, many cores.
-  const maxWorkers = parseInt(process.env.JSII_ROSETTA_MAX_WORKER_COUNT ?? '16');
-  const N = Math.min(maxWorkers, Math.max(1, Math.ceil(os.cpus().length / 2)));
+  const N = process.env.JSII_ROSETTA_MAX_WORKER_COUNT
+    ? parseInt(process.env.JSII_ROSETTA_MAX_WORKER_COUNT)
+    : Math.min(16, Math.max(1, Math.ceil(os.cpus().length / 2)));
   const snippetArr = Array.from(snippets);
   logging.info(`Translating ${snippetArr.length} snippets using ${N} workers`);
 


### PR DESCRIPTION
According to the README, `process.env.JSII_ROSETTA_MAX_WORKER_COUNT` should override the other logic. It currently does not.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0