### PR TITLE
fix(python): proscribe multiline assignments

### DIFF
--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -323,7 +323,6 @@ export class PythonVisitor extends DefaultVisitor<PythonLanguageContext> {
         ')',
       ],
       [],
-      { canBreakLine: true },
     );
   }
 
@@ -518,7 +517,6 @@ export class PythonVisitor extends DefaultVisitor<PythonLanguageContext> {
     return new OTree(
       [context.convert(node.expression), '(', this.convertFunctionCallArguments(node.arguments, context), ')'],
       [],
-      { canBreakLine: true },
     );
   }
 

--- a/test/translations/statements/multiline_var_define.cs
+++ b/test/translations/statements/multiline_var_define.cs
@@ -1,0 +1,4 @@
+var a = "hello";
+var b = Foo("bar");
+var c =
+new F();

--- a/test/translations/statements/multiline_var_define.go
+++ b/test/translations/statements/multiline_var_define.go
@@ -1,0 +1,4 @@
+a := "hello"
+b := foo(jsii.String("bar"))
+c :=
+NewF()

--- a/test/translations/statements/multiline_var_define.java
+++ b/test/translations/statements/multiline_var_define.java
@@ -1,0 +1,4 @@
+String a = "hello";
+Object b = foo("bar");
+Object c =
+new F();

--- a/test/translations/statements/multiline_var_define.py
+++ b/test/translations/statements/multiline_var_define.py
@@ -1,0 +1,3 @@
+a = "hello"
+b = foo("bar")
+c = F()

--- a/test/translations/statements/multiline_var_define.ts
+++ b/test/translations/statements/multiline_var_define.ts
@@ -1,0 +1,6 @@
+let a =
+    "hello";
+let b =
+    foo("bar");
+let c =
+    new F();


### PR DESCRIPTION
This fixes https://github.com/aws/jsii/issues/3968 by disallowing line breaks before `regularCallExpression` and `newExpression`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0