### PR TITLE
chore: untangle runtime from config code

### DIFF
--- a/projenrc/support.ts
+++ b/projenrc/support.ts
@@ -1,5 +1,13 @@
 import { JsonFile, Project } from 'projen';
-import type { ReleasesDocument } from '../src/support';
+
+type ReleaseLine = `${number}.${number}`;
+type VersionNumber = `${number}.${number}.${number}`;
+interface ReleasesDocument {
+  readonly current: ReleaseLine;
+  readonly currentMinVersionNumber: VersionNumber;
+  readonly maintenance: { readonly [release: ReleaseLine]: Date };
+  readonly endOfSupport?: readonly ReleaseLine[];
+}
 
 export const SUPPORT_POLICY: ReleasesDocument = {
   current: '5.3',

--- a/src/support.ts
+++ b/src/support.ts
@@ -13,11 +13,6 @@ export interface ReleasesDocument {
    * The release line that occupies the 'Current' stage.
    */
   readonly current: ReleaseLine;
-
-  /**
-   * The release line that occupies the 'Current' stage.
-   */
-  readonly currentMinVersionNumber: VersionNumber;
   /**
    * Release lines currently in 'Maintenance' with the date at which they are
    * planned to go into the 'End-of-Support' stage. This date should always be
@@ -157,4 +152,3 @@ function veryVisibleMessage(formatter: chalk.Chalk, ...lines: readonly string[])
 }
 
 type ReleaseLine = `${number}.${number}`;
-type VersionNumber = `${number}.${number}.${number}`;


### PR DESCRIPTION
In #530 we made a change to ReleasesDocument.
This was intended as a configuration change, but the interface resides in runtime code. The change broke the automatic backporting of configuration updates to maintenance branches, because we don't auto-backport runtime code.

The solution is that we do not mix config and runtime code, so backporting config will always be complete.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0