### PR TITLE
chore: make backport component backwards compatible

### DIFF
--- a/projenrc/pull-request-backport.ts
+++ b/projenrc/pull-request-backport.ts
@@ -60,7 +60,7 @@ export class PullRequestBackport extends Component {
       );
     }
 
-    const branches = options.branches ?? release.Release.of(this.project)?.branches ?? [];
+    const branches = options.branches ?? release.Release.of(this.project as any)?.branches ?? [];
     if (branches.length === 0) {
       this.project.logger.warn(
         'PullRequestBackport could not find any target branches. Backports will not be available. Please add release branches or configure `branches` manually.',


### PR DESCRIPTION
The PR backport component was implemented using a recent version of projen. The automatic config backport runs BEFORE dependencies are upgrades. That means we use the backported config with a not-updated version of projen.

In most cases this is fine, because the versions won't be very different. However currently we are running behind projen upgrades, so the versions have diverged a lot, which in turn causes a type error.

This change avoids the type error to unblock the automatic config backport and dependency upgrades. I have verified that this is really just type error and the code still works fine.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0