### PR TITLE
fix: 'TargetLanguage' has no exported member 'VISUALIZE'

### DIFF
--- a/src/languages/target-language.ts
+++ b/src/languages/target-language.ts
@@ -11,7 +11,9 @@ export enum TargetLanguage {
 
 const VALID_TARGET_LANGUAGES = new Set(Object.values(TargetLanguage));
 
-export function targetName(language: TargetLanguage.PYTHON | TargetLanguage.VISUALIZE): 'python';
+/** @internal an alias of PYTHON to make intent clear when language is irrelevant */
+export function targetName(language: TargetLanguage.VISUALIZE): 'python';
+export function targetName(language: TargetLanguage.PYTHON): 'python';
 export function targetName(language: TargetLanguage.CSHARP): 'dotnet';
 export function targetName(language: TargetLanguage.JAVA): 'java';
 export function targetName(language: TargetLanguage.GO): 'go';


### PR DESCRIPTION
The signature overwrite for targetName using TargetLanguage.VISUALIZE causes and error, because the enum value is stripped from the generate type declarations. We need to also strip the signature overwrite.

I manually checked the output to confirm. Not sure how else to test this.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0