### PR TITLE
fix: error TS2339: Property 'VISUALIZE' does not exist on type 'typeof TargetLanguage'

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -139,7 +139,12 @@
     },
     "post-compile": {
       "name": "post-compile",
-      "description": "Runs after successful compilation"
+      "description": "Runs after successful compilation",
+      "steps": [
+        {
+          "exec": "tsc --noEmit lib/index.d.ts -t es2020 -m nodenext"
+        }
+      ]
     },
     "post-upgrade": {
       "name": "post-upgrade",

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -62,6 +62,9 @@
       "steps": [
         {
           "exec": "tsc --build"
+        },
+        {
+          "exec": "tsc lib/index.d.ts --noEmit --skipLibCheck -t es2020 -m nodenext"
         }
       ]
     },
@@ -139,12 +142,7 @@
     },
     "post-compile": {
       "name": "post-compile",
-      "description": "Runs after successful compilation",
-      "steps": [
-        {
-          "exec": "tsc --noEmit lib/index.d.ts -t es2020 -m nodenext"
-        }
-      ]
+      "description": "Runs after successful compilation"
     },
     "post-upgrade": {
       "name": "post-upgrade",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -142,8 +142,8 @@ const project = new typescript.TypeScriptProject({
 
 // Double check emitted type declarations are valid
 // This is needed because we are ignoring some declarations, which may produce invalid type declarations if not carefully crafted
-project.postCompileTask.exec(
-  `tsc --noEmit lib/index.d.ts -t ${project.tsconfig?.compilerOptions?.target} -m ${project.tsconfig?.compilerOptions?.module}`,
+project.compileTask.exec(
+  `tsc lib/index.d.ts --noEmit --skipLibCheck -t ${project.tsconfig?.compilerOptions?.target} -m ${project.tsconfig?.compilerOptions?.module}`,
 );
 
 // PR validation should run on merge group, too...

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -53,7 +53,7 @@ const project = new typescript.TypeScriptProject({
     compilerOptions: {
       // @see https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
       lib: ['es2020', 'es2021.WeakRef'],
-      target: 'ES2020',
+      target: 'es2020',
       moduleResolution: javascript.TypeScriptModuleResolution.NODE_NEXT,
       module: 'nodenext',
       esModuleInterop: false,
@@ -139,6 +139,12 @@ const project = new typescript.TypeScriptProject({
     'yargs',
   ],
 });
+
+// Double check emitted type declarations are valid
+// This is needed because we are ignoring some declarations, which may produce invalid type declarations if not carefully crafted
+project.postCompileTask.exec(
+  `tsc --noEmit lib/index.d.ts -t ${project.tsconfig?.compilerOptions?.target} -m ${project.tsconfig?.compilerOptions?.module}`,
+);
 
 // PR validation should run on merge group, too...
 (project.tryFindFile('.github/workflows/pull-request-lint.yml')! as YamlFile).patch(

--- a/src/languages/target-language.ts
+++ b/src/languages/target-language.ts
@@ -1,28 +1,30 @@
 import * as assert from 'node:assert';
 
 export enum TargetLanguage {
-  /** @internal an alias of PYTHON to make intent clear when language is irrelevant */
-  VISUALIZE = 'python',
   PYTHON = 'python',
   CSHARP = 'csharp',
   JAVA = 'java',
   GO = 'go',
+  /** @internal an alias of PYTHON to make intent clear when language is irrelevant, must be last */
+  VISUALIZE = 'python',
 }
 
 const VALID_TARGET_LANGUAGES = new Set(Object.values(TargetLanguage));
 
-/** @internal an alias of PYTHON to make intent clear when language is irrelevant */
-export function targetName(language: TargetLanguage.VISUALIZE): 'python';
+export function targetName(language: TargetLanguage): 'python' | 'dotnet' | 'java' | 'go';
 export function targetName(language: TargetLanguage.PYTHON): 'python';
 export function targetName(language: TargetLanguage.CSHARP): 'dotnet';
 export function targetName(language: TargetLanguage.JAVA): 'java';
 export function targetName(language: TargetLanguage.GO): 'go';
-export function targetName(language: TargetLanguage): 'python' | 'dotnet' | 'java' | 'go';
+/** @internal an alias of PYTHON to make intent clear when language is irrelevant, must be last override */
+export function targetName(language: TargetLanguage.VISUALIZE): 'python';
+
 /**
  * @param language a possible value for `TargetLanguage`.
  *
  * @returns the name of the target configuration block for the given language.
  */
+export function targetName(language: TargetLanguage): 'python' | 'dotnet' | 'java' | 'go';
 export function targetName(language: TargetLanguage): 'python' | 'dotnet' | 'java' | 'go' {
   // The TypeScript compiler should guarantee the below `switch` statement covers all possible
   // values of the TargetLanguage enum, but we add an assert here for clarity of intent.

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -24,7 +24,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020",
+    "target": "es2020",
     "moduleResolution": "nodenext",
     "noImplicitOverride": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020",
+    "target": "es2020",
     "moduleResolution": "nodenext",
     "noImplicitOverride": true,
     "skipLibCheck": true,


### PR DESCRIPTION
We are using the `@internal` directive to instruct typescript compiler to drop some statements during compilation.
This may cause the compiler to emit invalid declarations if we are not careful.
To guarantee that our declarations are valid, we do an additional run of tsc on the output.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0