### PR TITLE
chore(ci): fix backport workflow is failing when PR is not yet merged

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,6 +13,7 @@ jobs:
     permissions: {}
     steps:
       - name: Backport Action
+        if: github.event.pull_request.merged == true
         uses: sqren/backport-github-action@v9.3.0
         with:
           github_token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/projenrc/pull-request-backport.ts
+++ b/projenrc/pull-request-backport.ts
@@ -105,6 +105,9 @@ export class PullRequestBackport extends Component {
         {
           name: 'Backport Action',
           uses: 'sqren/backport-github-action@v9.3.0',
+          // only run when the PR is merged successfully
+          // this is to prevent workflow failures when labeling a still open PR
+          if: 'github.event.pull_request.merged == true',
           with: {
             github_token: workflowEngine.projenCredentials.tokenRef,
             auto_backport_label_prefix: options.labelPrefix ?? 'backport-to-',


### PR DESCRIPTION

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0