### PR TITLE
fix: extracting snippets cause large spike in file system access

### DIFF
--- a/src/commands/transliterate.ts
+++ b/src/commands/transliterate.ts
@@ -51,7 +51,7 @@ export interface TransliterateAssemblyOptions {
 
 /**
  * Prepares transliterated versions of the designated assemblies into the
- * selected taregt languages.
+ * selected target languages.
  *
  * @param assemblyLocations the directories which contain assemblies to
  *                          transliterate.

--- a/src/snippet.ts
+++ b/src/snippet.ts
@@ -149,7 +149,7 @@ export function typeScriptSnippetFromVisibleSource(
   parameters: Record<string, string> = {},
 ): TypeScriptSnippet {
   const [source, sourceParameters] = parametersFromSourceDirectives(typeScriptSource);
-  const visibleSource = source.trimRight();
+  const visibleSource = source.trimEnd();
 
   return {
     visibleSource,


### PR DESCRIPTION
The parallel execution of `withDependencies` inside `allTypeScriptSnippets` caused a large spike in access to the file system. On systems with only a low number of available file descriptors, this will cause transliteration to fail.

Downstream tools usually run transliteration once and cache the results for additional runs. For example when converting individual submodules of an assembly. When transliteration fails, caches cannot be written, which ultimately leads to extremely long and still failing execution times for these tools.

This change causes a moderate slow-down of factor 1.03 ± 0.14 compared to previous code (see benchmark). To resolve the issue, this is acceptable. During debugging I noticed a number of potential future performance improvements, including (re-)introducing parallelism but configurable.

---

Performance Benchmark

```console
Benchmark 1: current
  Time (mean ± σ):     55.860 s ±  5.278 s    [User: 66.506 s, System: 24.723 s]
  Range (min … max):   51.892 s … 65.035 s    5 runs

Benchmark 2: proposed
  Time (mean ± σ):     57.558 s ±  5.921 s    [User: 62.496 s, System: 24.227 s]
  Range (min … max):   54.599 s … 68.137 s    5 runs

Summary
  current ran
    1.03 ± 0.14 times faster than proposed
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0