### PR TITLE
fix: correct Node.js minimum version

### DIFF
--- a/.github/workflows/auto-tag-dev-v5.7.yml
+++ b/.github/workflows/auto-tag-dev-v5.7.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-dev-v5.8.yml
+++ b/.github/workflows/auto-tag-dev-v5.8.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-dev.yml
+++ b/.github/workflows/auto-tag-dev.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-releases-v5.7.yml
+++ b/.github/workflows/auto-tag-releases-v5.7.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-releases-v5.8.yml
+++ b/.github/workflows/auto-tag-releases-v5.8.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "18"
           cache: yarn
       - name: Cache build outputs
         if: github.event_name == 'pull_request'
@@ -130,6 +130,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 18.x
           - 20.x
           - 22.x
           - 24.x
@@ -163,7 +164,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "18"
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: "20"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Prepare Release
@@ -131,7 +131,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           always-auth: true
-          node-version: "20"
+          node-version: "18"
           registry-url: https://registry.npmjs.org/
       - name: Federate to AWS
         uses: aws-actions/configure-aws-credentials@v4

--- a/.kiro/steering/new-jsii-compiler-version.md
+++ b/.kiro/steering/new-jsii-compiler-version.md
@@ -65,9 +65,13 @@ Edit `projenrc/support.ts`:
 
 ### 5. Update Minimum Node.js Version
 
-In `.projenrc.ts`, update `minNodeVersion` to the oldest LTS version of Node.js, dropping support for EOL versions.
+In `.projenrc.ts`, update `minNodeVersion` following the AWS CDK extended support policy. The CDK supports Node.js versions for 6 months beyond their official End-of-Life (EOL) dates.
 
-Check current Node.js LTS versions:
+Check the current CDK Node.js support timeline: https://docs.aws.amazon.com/cdk/v2/guide/node-versions.html#node-version-timeline
+
+Update `minNodeVersion` to the oldest Node.js version that is still supported by CDK (including the 6-month extension period), not just the official Node.js LTS versions.
+
+Check current Node.js LTS versions for reference:
 
 ```bash
 curl -s https://raw.githubusercontent.com/nodejs/Release/main/schedule.json | jq -r 'to_entries[] | select(.value.lts != null) | "\(.key): LTS \(.value.lts) - End: \(.value.end)"'

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^20",
+      "version": "^18",
       "type": "build"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -148,7 +148,7 @@
     },
     {
       "name": "jsii",
-      "version": "~5.9.0",
+      "version": "~5.9.1",
       "type": "runtime"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -35,7 +35,7 @@ const project = new typescript.TypeScriptProject({
 
   autoDetectBin: true,
 
-  minNodeVersion: '20.9.0',
+  minNodeVersion: '18.12.0',
   tsconfig: {
     compilerOptions: {
       // @see https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "chalk": "^4",
     "commonmark": "^0.31.2",
     "fast-glob": "^3.3.3",
-    "jsii": "~5.9.0",
+    "jsii": "~5.9.1",
     "semver": "^7.7.2",
     "semver-intersect": "^1.5.0",
     "stream-json": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/commonmark": "^0.27.10",
     "@types/jest": "^29.5.14",
     "@types/mock-fs": "^4.13.4",
-    "@types/node": "^20",
+    "@types/node": "^18",
     "@types/semver": "^7.7.0",
     "@types/stream-json": "^1.7.8",
     "@types/tar": "^6.1.13",
@@ -80,7 +80,7 @@
     "yargs": "^17.7.2"
   },
   "engines": {
-    "node": ">= 20.9.0"
+    "node": ">= 18.12.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/projenrc/support.ts
+++ b/projenrc/support.ts
@@ -12,7 +12,7 @@ interface ReleasesDocument {
 export const SUPPORT_POLICY: ReleasesDocument = {
   current: '5.9',
   // Define a different patch version here if a specific feature or bug-fix
-  currentMinVersionNumber: '5.9.0',
+  currentMinVersionNumber: '5.9.1',
   maintenance: {
     // version: End-of-support date
     '5.0': new Date('2024-01-31'),

--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,6 @@
 {
   "current": "5.9",
-  "currentMinVersionNumber": "5.9.0",
+  "currentMinVersionNumber": "5.9.1",
   "maintenance": {
     "5.0": "2024-01-31T00:00:00.000Z",
     "5.1": "2024-04-30T00:00:00.000Z",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,12 +1054,12 @@
   dependencies:
     undici-types "~7.10.0"
 
-"@types/node@^20":
-  version "20.19.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.9.tgz#ca9a58193fec361cc6e859d88b52261853f1f0d3"
-  integrity sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==
+"@types/node@^18":
+  version "18.19.121"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.121.tgz#c50d353ea2d1fb1261a8bbd0bf2850306f5af2b3"
+  integrity sha512-bHOrbyztmyYIi4f1R0s17QsPs1uyyYnGcXeZoGEd227oZjry0q6XQBQxd82X1I57zEfwO8h9Xo+Kl5gX1d9MwQ==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -3556,10 +3556,10 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
-jsii@~5.9.0:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.9.0.tgz#ae4d6b21e2b5f7db5c3f01fe1e384ff1a2191fd9"
-  integrity sha512-g4kDIZjK8e6urtrtzOMQ99Gpb6NMPjNY/fLDpeOlTqSKdcYds+C8jpYU7jFFbhgyQKN05HRY1HpqlKDOzXGr1g==
+jsii@~5.9.1:
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.9.1.tgz#0b90ab43d82dbf025bfdd4077b892cbbe7c8d3c2"
+  integrity sha512-0fosDxjcd2DTslZ2Thsx8t+kmXYPRTcgPNVYxj3qPV+OGocjIRV8jdBAw5HoGXN/h8eq2eiQKaCs6zSjtFI3RQ==
   dependencies:
     "@jsii/check-node" "1.113.0"
     "@jsii/spec" "^1.113.0"
@@ -5006,10 +5006,10 @@ unbox-primitive@^1.1.0:
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
 
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici-types@~7.10.0:
   version "7.10.0"


### PR DESCRIPTION
Update minNodeVersion following AWS CDK extended support policy.

This ensures compatibility with the latest CDK Node.js support timeline and removes support for Node.js versions that are no longer supported by CDK (including the 6-month extension period).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0