### PR TITLE
chore: release workflow won't release dev releases

### DIFF
--- a/projenrc/tag-release.ts
+++ b/projenrc/tag-release.ts
@@ -182,19 +182,6 @@ async function main(): Promise<void> {
     );
   }
 
-  // Check that the current commit wasn't already tagged...
-  const existingTag = tags.find((tag) => tag.commit === HEAD);
-  if (existingTag != null) {
-    const message = `Commit ${HEAD} was already tagged as ${existingTag.tag.version}!`;
-    if (idempotent) {
-      console.info(message);
-      console.log('Idempotent success!');
-      return;
-    } else {
-      throw new Error(message);
-    }
-  }
-
   // Make sure we have all remote tags pulled in.
   await git('fetch', remote, `refs/tags/v${versionMajorMinor}.*:refs/tags/v${versionMajorMinor}.*`);
 


### PR DESCRIPTION
Tagging can be done for pre-releases, as well as for official releases. For the purposes of this PR body, we will call those different styles of tag a "tag class".

The tagging workflow works this way:

1. If the current commit is already tagged, stop.
2. Fetch all tags.
3. If the current commit is already tagged with an equivalent or higher tag class, stop.

The upshot of this is that if the current commit is already tagged as a `dev` tag, through check (1) it will not be tagged again as an official release; we never reach check (3) which would have correctly ignored pre-release tags.

It seems like check (3) fully subsumes check (1), so I'm removing check (1).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0