### PR TITLE
fix(release): packages not released with npm provenance attestations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,17 +20,17 @@ jobs:
       CI: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Enable corepack
         run: corepack enable
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: yarn
       - name: Cache build outputs
         if: github.event_name == 'pull_request'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: build-outputs-${{ hashFiles('tsconfig.json', 'build-tools/**/*.ts', 'src/**/*.ts', 'package.json', 'yarn.lock') }}
           path: |-
@@ -50,11 +50,12 @@ jobs:
           git diff --staged --patch --exit-code > .repo.patch || echo "needed=true" >> $GITHUB_OUTPUT
       - name: Upload patch
         if: steps.self-mutation.outputs.needed
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: .repo.patch
           path: .repo.patch
           overwrite: true
+          include-hidden-files: true
       - name: Fail if self-mutation is needed
         if: steps.self-mutation.outputs.needed
         run: |-
@@ -62,7 +63,7 @@ jobs:
           cat .repo.patch
           exit 1
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: build-output
           path: |-
@@ -70,6 +71,7 @@ jobs:
             !${{ github.workspace }}/node_modules
             !${{ github.workspace }}/fixtures/node_modules
           overwrite: true
+          include-hidden-files: true
   self-mutation:
     needs: build
     runs-on: ubuntu-latest
@@ -80,13 +82,13 @@ jobs:
     if: always() && (github.event_name == 'pull_request') && needs.build.outputs.self-mutation-needed && (github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
       - name: Download patch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: .repo.patch
           path: ${{ runner.temp }}
@@ -111,14 +113,14 @@ jobs:
     if: success()
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-output
           path: ${{ github.workspace }}
       - name: Enable corepack
         run: corepack enable
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -160,14 +162,14 @@ jobs:
       CI: "true"
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-output
           path: ${{ github.workspace }}
       - name: Enable corepack
         run: corepack enable
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: yarn
@@ -176,8 +178,9 @@ jobs:
       - name: Package
         run: npx projen package
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: release-package
           path: ${{ github.workspace }}/dist
           overwrite: true
+          include-hidden-files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         run: yarn ts-node projenrc/publish-target.ts ${{ github.ref_name }}
       - name: Federate to AWS
         if: fromJSON(steps.publish-target.outputs.github-release)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -73,11 +73,12 @@ jobs:
           unset passphrase
           find ${GNUPGHOME} -type f -exec shred --remove {} \;
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: release-package
           path: ${{ github.workspace }}/dist
           overwrite: true
+          include-hidden-files: true
   release-to-github:
     name: Create GitHub Release
     needs: build
@@ -89,7 +90,7 @@ jobs:
     if: fromJSON(needs.build.outputs.github-release)
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-package
       - name: Verify if release exists
@@ -128,19 +129,18 @@ jobs:
       CI: "true"
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-package
       - name: Enable corepack
         run: corepack enable
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          always-auth: true
           node-version: "20"
           registry-url: https://registry.npmjs.org/
       - name: Federate to AWS
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -154,7 +154,7 @@ jobs:
           echo "NODE_AUTH_TOKEN=${token}" >> $GITHUB_ENV
           unset token
       - name: Publish
-        run: npm publish ${{ github.workspace }}/js/jsii-*.tgz --access=public --tag=${{ needs.build.outputs.dist-tag }}
+        run: npm publish ${{ github.workspace }}/js/jsii-*.tgz --access=public --provenance --tag=${{ needs.build.outputs.dist-tag }}
       - name: Tag "latest"
         if: fromJSON(needs.build.outputs.latest)
         run: npm dist-tag add jsii-rosetta@${{ github.ref_name }} latest

--- a/projenrc/build-workflow.ts
+++ b/projenrc/build-workflow.ts
@@ -55,7 +55,7 @@ export class BuildWorkflow {
         steps: [
           {
             name: 'Checkout',
-            uses: 'actions/checkout@v4',
+            uses: 'actions/checkout@v6',
           },
           {
             name: 'Enable corepack',
@@ -63,7 +63,7 @@ export class BuildWorkflow {
           },
           {
             name: 'Setup Node.js',
-            uses: 'actions/setup-node@v4',
+            uses: 'actions/setup-node@v6',
             with: {
               'node-version': nodeVersion,
               'cache': 'yarn',
@@ -72,7 +72,7 @@ export class BuildWorkflow {
           {
             name: 'Cache build outputs',
             if: "github.event_name == 'pull_request'",
-            uses: 'actions/cache@v3',
+            uses: 'actions/cache@v4',
             with: {
               'key':
                 "build-outputs-${{ hashFiles('tsconfig.json', 'build-tools/**/*.ts', 'src/**/*.ts', 'package.json', 'yarn.lock') }}",
@@ -102,11 +102,12 @@ export class BuildWorkflow {
           {
             name: 'Upload patch',
             if: 'steps.self-mutation.outputs.needed',
-            uses: 'actions/upload-artifact@v4.3.6',
+            uses: 'actions/upload-artifact@v7',
             with: {
-              name: '.repo.patch',
-              path: '.repo.patch',
-              overwrite: true,
+              'name': '.repo.patch',
+              'path': '.repo.patch',
+              'overwrite': true,
+              'include-hidden-files': true,
             },
           },
           {
@@ -121,16 +122,17 @@ export class BuildWorkflow {
 
           {
             name: 'Upload artifact',
-            uses: 'actions/upload-artifact@v4.3.6',
+            uses: 'actions/upload-artifact@v7',
             with: {
-              name: 'build-output',
-              path: [
+              'name': 'build-output',
+              'path': [
                 '${{ github.workspace }}',
                 // Exclude node_modules to reduce artifact size (we won't use those anyway)...
                 '!${{ github.workspace }}/node_modules',
                 '!${{ github.workspace }}/fixtures/node_modules',
               ].join('\n'),
-              overwrite: true,
+              'overwrite': true,
+              'include-hidden-files': true,
             },
           },
         ],
@@ -144,7 +146,7 @@ export class BuildWorkflow {
         steps: [
           {
             name: 'Checkout',
-            uses: 'actions/checkout@v4',
+            uses: 'actions/checkout@v6',
             with: {
               ref: '${{ github.event.pull_request.head.ref }}',
               repository: '${{ github.event.pull_request.head.repo.full_name }}',
@@ -153,7 +155,7 @@ export class BuildWorkflow {
           },
           {
             name: 'Download patch',
-            uses: 'actions/download-artifact@v4',
+            uses: 'actions/download-artifact@v8',
             with: {
               name: '.repo.patch',
               path: '${{ runner.temp }}',
@@ -207,7 +209,7 @@ export class BuildWorkflow {
         steps: [
           {
             name: 'Download artifact',
-            uses: 'actions/download-artifact@v4',
+            uses: 'actions/download-artifact@v8',
             with: { name: 'build-output', path: '${{ github.workspace }}' },
           },
           {
@@ -216,7 +218,7 @@ export class BuildWorkflow {
           },
           {
             name: 'Setup Node.js',
-            uses: 'actions/setup-node@v4',
+            uses: 'actions/setup-node@v6',
             with: {
               'node-version': '${{ matrix.node-version }}',
               'cache': 'yarn',
@@ -267,7 +269,7 @@ export class BuildWorkflow {
         steps: [
           {
             name: 'Download artifact',
-            uses: 'actions/download-artifact@v4',
+            uses: 'actions/download-artifact@v8',
             with: { name: 'build-output', path: '${{ github.workspace }}' },
           },
           {
@@ -276,7 +278,7 @@ export class BuildWorkflow {
           },
           {
             name: 'Setup Node.js',
-            uses: 'actions/setup-node@v4',
+            uses: 'actions/setup-node@v6',
             with: {
               'node-version': nodeVersion,
               'cache': 'yarn',
@@ -292,11 +294,12 @@ export class BuildWorkflow {
           },
           {
             name: 'Upload artifact',
-            uses: 'actions/upload-artifact@v4.3.6',
+            uses: 'actions/upload-artifact@v7',
             with: {
-              name: 'release-package',
-              path: '${{ github.workspace }}/dist',
-              overwrite: true,
+              'name': 'release-package',
+              'path': '${{ github.workspace }}/dist',
+              'overwrite': true,
+              'include-hidden-files': true,
             },
           },
         ],

--- a/projenrc/release.ts
+++ b/projenrc/release.ts
@@ -28,7 +28,7 @@ export class ReleaseWorkflow {
     const publishTarget = 'publish-target';
     const federateToAwsStep: github.workflows.JobStep = {
       name: 'Federate to AWS',
-      uses: 'aws-actions/configure-aws-credentials@v4',
+      uses: 'aws-actions/configure-aws-credentials@v6',
       with: {
         'aws-region': 'us-east-1',
         'role-to-assume': '${{ secrets.AWS_ROLE_TO_ASSUME }}',
@@ -114,11 +114,12 @@ export class ReleaseWorkflow {
         },
         {
           name: 'Upload artifact',
-          uses: 'actions/upload-artifact@v4.3.6',
+          uses: 'actions/upload-artifact@v7',
           with: {
-            name: releasePackageName,
-            path: '${{ github.workspace }}/dist',
-            overwrite: true,
+            'name': releasePackageName,
+            'path': '${{ github.workspace }}/dist',
+            'overwrite': true,
+            'include-hidden-files': true,
           },
         },
       ],
@@ -126,7 +127,7 @@ export class ReleaseWorkflow {
 
     const downloadArtifactStep: github.workflows.JobStep = {
       name: 'Download artifact',
-      uses: 'actions/download-artifact@v4',
+      uses: 'actions/download-artifact@v8',
       with: {
         name: releasePackageName,
       },
@@ -225,9 +226,8 @@ export class ReleaseWorkflow {
         },
         {
           name: 'Setup Node.js',
-          uses: 'actions/setup-node@v4',
+          uses: 'actions/setup-node@v6',
           with: {
-            'always-auth': true,
             'node-version': nodeVersion,
             'registry-url': `https://registry.npmjs.org/`,
           },
@@ -249,6 +249,7 @@ export class ReleaseWorkflow {
           run: [
             'npm publish ${{ github.workspace }}/js/jsii-*.tgz',
             '--access=public',
+            '--provenance',
             `--tag=\${{ needs.build.outputs.${PublishTargetOutput.DIST_TAG} }}`,
           ].join(' '),
         },


### PR DESCRIPTION
Adds npm provenance attestations to the release workflow via `--provenance`, enabling consumers to verify packages were built from this repository's CI.

Also updates all GitHub Actions to their latest Node 24 compatible major versions before the June 2, 2026 deadline when Node.js 20 actions will be forced to run on Node.js 24, and removes the deprecated `always-auth` input from `actions/setup-node@v6`.

Mirrors https://github.com/aws/jsii-compiler/pull/2652.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
