### PR TITLE
fix: make upgrade maintenance workflow functional

### DIFF
--- a/.github/workflows/upgrade-maintenance-v5.9.yml
+++ b/.github/workflows/upgrade-maintenance-v5.9.yml
@@ -25,12 +25,12 @@ jobs:
         with:
           node-version: lts/*
           package-manager-cache: false
+      - name: Install dependencies
+        run: yarn install --immutable
       - name: Back-port projenrc changes from main
         env:
           CI: "false"
         run: git fetch origin main && git checkout FETCH_HEAD -- README.md && yarn projen
-      - name: Install dependencies
-        run: yarn install --immutable
       - name: Upgrade dependencies
         run: yarn projen upgrade
       - name: Find mutations

--- a/projenrc/upgrade-dependencies.ts
+++ b/projenrc/upgrade-dependencies.ts
@@ -29,7 +29,9 @@ export class JsiiDependencyUpgrades extends Component {
     for (const upgradeWorkflow of upgrades.workflows) {
       if (upgradeWorkflow.name.startsWith('upgrade-maintenance-')) {
         upgradeWorkflow.file?.patch(
-          JsonPatch.add('/jobs/upgrade/steps/3', {
+          // Insert after the "Install dependencies" step (index 4), since the
+          // back-port runs `yarn projen` which requires node_modules to exist.
+          JsonPatch.add('/jobs/upgrade/steps/4', {
             name: 'Back-port projenrc changes from main',
             env: { CI: 'false' },
             run: 'git fetch origin main && git checkout FETCH_HEAD -- README.md && yarn projen',


### PR DESCRIPTION
This workflow has never worked because we were attempting to perform the projen backport before we installed dependencies. Since dependencies aren't installed, then `node_modules` doesn't exist yet which causes the backport with `yarn projen` to fail with `Couldn't find the node_modules state file - running an install might help (findPackageLocation)`. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0