### PR TITLE
chore: release fails for tags on maintenance branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           ref: ${{ github.sha }}
           repository: ${{ github.repository }}
-      - name: Fetch main for yarn version
-        run: git fetch --depth=1 origin main:main
+          filter: blob:none
       - name: Enable corepack
         run: corepack enable
       - name: Setup Node.js

--- a/projenrc/release.ts
+++ b/projenrc/release.ts
@@ -36,6 +36,22 @@ export class ReleaseWorkflow {
       },
     };
 
+    // `yarn version` resolves the release strategy via a merge-base between
+    // HEAD and `origin/main`. For tags on maintenance branches that fork point
+    // is far back, so we need the full commit graph (`fetch-depth: 0`) - but
+    // not historical file contents, hence `filter: blob:none`.
+    const checkoutStep = github.WorkflowSteps.checkout({
+      with: {
+        ref: '${{ github.sha }}',
+        repository: '${{ github.repository }}',
+        fetchDepth: 0,
+      },
+    });
+    const releaseCheckoutStep: github.workflows.JobStep = {
+      ...checkoutStep,
+      with: { ...checkoutStep.with, filter: 'blob:none' },
+    };
+
     release.addJob('build', {
       name: 'Build release package',
       env: {
@@ -53,16 +69,7 @@ export class ReleaseWorkflow {
       },
       runsOn: ['ubuntu-latest'],
       steps: [
-        github.WorkflowSteps.checkout({
-          with: { ref: '${{ github.sha }}', repository: '${{ github.repository }}' },
-        }),
-        {
-          // `yarn version` needs a common ancestor with `main` to determine the
-          // release strategy. The default checkout is shallow and tag-only, so
-          // we fetch the tip of `main` to give yarn an ancestor to diff against.
-          name: 'Fetch main for yarn version',
-          run: 'git fetch --depth=1 origin main:main',
-        },
+        releaseCheckoutStep,
         ...workflowSetup(this.project),
         {
           name: 'Prepare Release',


### PR DESCRIPTION
The release workflow fails on every tag pushed to a maintenance branch, for example `v5.9.53-dev.0` on `maintenance/v5.9`, with `No ancestor could be found between any of HEAD and master, origin/master, upstream/master, main, origin/main, upstream/main`.

Yarn Berry's `yarn version` resolves the release strategy by computing a merge-base between `HEAD` and one of its base refs (`origin/main`, ...). The earlier fix fetched `main` at depth 1, which works for tags on `main` because the tag is `main`'s tip and the merge-base is `HEAD` itself. It does not work for tags on maintenance branches: those branches forked from `main` far back in history, so a depth-1 checkout of the tag combined with a depth-1 fetch of `main` never contains the fork point, and no common ancestor can be found.

This checks out the full commit graph instead, so the merge-base is resolvable regardless of which branch the tag lives on. The commit graph is what `yarn version` actually needs; the file contents of all of history are not, so a blobless partial clone (`filter: blob:none`) keeps the data cost down by fetching historical blobs lazily only if they are ever needed. Because `fetch-depth: 0` already brings in the `origin/main` base ref, the separate `main` fetch step is no longer necessary and has been removed.

This ports aws/jsii-compiler#2701 to jsii-rosetta.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
