### PR TITLE
chore: remove loop to manually add tsconfig files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,6 @@ jspm_packages/
 !/.github/workflows/upgrade-maintenance-v5.9.yml
 !/.github/workflows/upgrade-jsii-main.yml
 !/.github/workflows/upgrade-jsii-maintenance-v5.9.yml
-/build-tools/tsconfig.json
-/projenrc/tsconfig.json
-/test/tsconfig.json
-/test/translations/tsconfig.json
 !/.vscode/settings.json
 !/.vscode/extensions.json
 !/.github/workflows/build.yml

--- a/.projen/files.json
+++ b/.projen/files.json
@@ -26,13 +26,9 @@
     ".projen/tasks.json",
     ".vscode/extensions.json",
     ".vscode/settings.json",
-    "build-tools/tsconfig.json",
     "jest.config.json",
     "LICENSE",
-    "projenrc/tsconfig.json",
     "releases.json",
-    "test/translations/tsconfig.json",
-    "test/tsconfig.json",
     "tsconfig.dev.json",
     "tsconfig.json"
   ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,4 @@
-import { DependencyType, github, javascript, JsonFile, JsonPatch, typescript, YamlFile } from 'projen';
+import { DependencyType, github, javascript, JsonPatch, typescript, YamlFile } from 'projen';
 import { YarnNodeLinker } from 'projen/lib/javascript/yarnrc';
 import { BuildWorkflow } from './projenrc/build-workflow';
 import { ReleaseWorkflow } from './projenrc/release';

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -154,22 +154,6 @@ project.compileTask.exec(
 
 new JsiiDependencyUpgrades(project);
 
-// VSCode will look at the "closest" file named "tsconfig.json" when deciding on which config to use
-// for a given TypeScript file with the TypeScript language server. In order to make this "seamless"
-// we'll be dropping `tsconfig.json` files at strategic locations in the project. These will not be
-// committed as they are only here for VSCode comfort.
-for (const dir of ['build-tools', 'projenrc', 'test', 'test/translations']) {
-  new JsonFile(project, `${dir}/tsconfig.json`, {
-    allowComments: true,
-    committed: false,
-    marker: true,
-    obj: {
-      extends: '../tsconfig.dev.json',
-      references: [{ path: '../tsconfig.json' }],
-    },
-    readonly: true,
-  });
-}
 project.tsconfig?.file?.patch(
   JsonPatch.add('/compilerOptions/composite', true),
   JsonPatch.add('/compilerOptions/declarationMap', true),


### PR DESCRIPTION
We should not be doing this, works against projen


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0