### PR TITLE
chore: route PR head ref through an environment instead of inline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,10 +99,12 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Push changes
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |-
           git add .
           git commit -s -m "chore: self-mutation"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin "HEAD:$HEAD_REF"
   matrix-test:
     name: test (node ${{ matrix.node-version }})
     needs: build

--- a/projenrc/build-workflow.ts
+++ b/projenrc/build-workflow.ts
@@ -173,10 +173,16 @@ export class BuildWorkflow {
           },
           {
             name: 'Push changes',
+            // The branch name (`head.ref`) is user-controlled input and must not
+            // be interpolated directly into the shell command (script injection).
+            // Pass it through an environment variable and reference it quoted.
+            env: {
+              HEAD_REF: '${{ github.event.pull_request.head.ref }}',
+            },
             run: [
               'git add .',
               'git commit -s -m "chore: self-mutation"',
-              'git push origin HEAD:${{ github.event.pull_request.head.ref }}',
+              'git push origin "HEAD:$HEAD_REF"',
             ].join('\n'),
           },
         ],

--- a/projenrc/build-workflow.ts
+++ b/projenrc/build-workflow.ts
@@ -176,11 +176,9 @@ export class BuildWorkflow {
             env: {
               HEAD_REF: '${{ github.event.pull_request.head.ref }}',
             },
-            run: [
-              'git add .',
-              'git commit -s -m "chore: self-mutation"',
-              'git push origin "HEAD:$HEAD_REF"',
-            ].join('\n'),
+            run: ['git add .', 'git commit -s -m "chore: self-mutation"', 'git push origin "HEAD:$HEAD_REF"'].join(
+              '\n',
+            ),
           },
         ],
       },

--- a/projenrc/build-workflow.ts
+++ b/projenrc/build-workflow.ts
@@ -173,9 +173,6 @@ export class BuildWorkflow {
           },
           {
             name: 'Push changes',
-            // The branch name (`head.ref`) is user-controlled input and must not
-            // be interpolated directly into the shell command (script injection).
-            // Pass it through an environment variable and reference it quoted.
             env: {
               HEAD_REF: '${{ github.event.pull_request.head.ref }}',
             },


### PR DESCRIPTION
The "Push changes" step interpolated the user-controlled branch name `github.event.pull_request.head.ref` directly into the run shell command, allowing potential shell script injection.

I bind the value to a HEAD_REF environment variable and reference it as a quoted shell variable instead, per GitHub's hardening guidance

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0