### PR TITLE
fix: wrong Java and Go names for libraries that manage their own tsconfig.json

### DIFF
--- a/src/jsii/assemblies.ts
+++ b/src/jsii/assemblies.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { loadAssemblyFromFile, loadAssemblyFromPath, findAssemblyFile } from '@jsii/spec';
 import * as spec from '@jsii/spec';
 import { fixturize } from '../fixtures';
+import * as logging from '../logging';
 import { extractTypescriptSnippetsFromMarkdown } from '../markdown/extract-snippets';
 import {
   TypeScriptSnippet,
@@ -306,6 +307,111 @@ function loadLookupAssembly(directory: string): TypeLookupAssembly | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Look up the jsii fqn for a given symbolId in a `TypeLookupAssembly`
+ *
+ * The symbolId as computed from the TypeScript AST is not guaranteed to
+ * match the symbolId recorded in the assembly: symbolIds in the assembly are
+ * relative to the package's source root (`rootDir`), while the symbolId
+ * computed by a consumer is derived from the shipped `.d.ts` files (under
+ * `outDir`).
+ *
+ * `symbolIdentifier()` normalizes the path if it can determine both `rootDir`
+ * and `outDir`, but packages that manage their own `tsconfig.json` (via
+ * `jsii.tsconfig`) don't have `jsii.tsc` in their `package.json`, and their
+ * `tsconfig.json` is typically not published to npm. In that case the computed
+ * symbolId comes out as (e.g.) `lib/construct:Construct` while the assembly
+ * records `src/construct:Construct`, and a direct map lookup misses.
+ *
+ * To compensate, if the direct lookup fails we try to reconstruct the source
+ * path ourselves:
+ *
+ * - If the assembly records the `outDir` in its metadata (`tscOutDir`, written
+ *   by newer jsii compilers, symmetric with `tscRootDir`), we re-root the path
+ *   exactly.
+ * - Otherwise (e.g. `constructs@10.8.0`), we only know the `rootDir`, so we
+ *   progressively strip leading path segments (candidate `outDir`s) from the
+ *   computed symbolId, prepend the `rootDir`, and accept the first candidate
+ *   that matches a symbolId recorded in the assembly.
+ */
+export function resolveSymbolIdFqn(lookup: TypeLookupAssembly, symbolId: string): string | undefined {
+  const direct = lookup.symbolIdMap[symbolId];
+  if (direct !== undefined) {
+    return direct;
+  }
+
+  const metadata = lookup.assembly.metadata as { tscRootDir?: string; tscOutDir?: string } | undefined;
+  const tsc = lookup.packageJson.jsii?.tsc;
+  const rootDir = splitPrefix(tsc?.rootDir ?? metadata?.tscRootDir);
+  if (rootDir === undefined) {
+    return undefined;
+  }
+
+  const parts = symbolId.split(':');
+  if (parts.length !== 2) {
+    return undefined;
+  }
+  const [fileName, typeName] = parts;
+  const segments = fileName.split('/');
+
+  const outDir = splitPrefix(tsc?.outDir ?? metadata?.tscOutDir);
+  if (outDir !== undefined) {
+    // We know the exact outDir: re-root the path and do a single lookup
+    if (!outDir.every((seg, i) => segments[i] === seg)) {
+      return undefined;
+    }
+    return lookup.symbolIdMap[`${[...rootDir, ...segments.slice(outDir.length)].join('/')}:${typeName}`];
+  }
+
+  // The outDir is unknown: try candidate outDirs of increasing depth
+  for (let strip = 0; strip <= segments.length - 1; strip++) {
+    const found = lookup.symbolIdMap[`${[...rootDir, ...segments.slice(strip)].join('/')}:${typeName}`];
+    if (found !== undefined) {
+      return found;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Split a relative directory prefix into segments, treating '', '.' and undefined appropriately
+ */
+function splitPrefix(dir: string | undefined): string[] | undefined {
+  if (dir === undefined) {
+    return undefined;
+  }
+  return dir.split('/').filter((seg) => seg !== '' && seg !== '.');
+}
+
+/**
+ * Symbol ids we have already warned about, so we only warn once per unique failure
+ */
+const REPORTED_UNRESOLVED_SYMBOL_IDS = new Set<string>();
+
+/**
+ * Warn (once per unique occurrence) that a symbolId could not be resolved against an assembly
+ *
+ * If we get here, the type demonstrably lives in a package with a jsii
+ * assembly, so we *should* have been able to resolve it. Failing to do so
+ * means the translation will silently fall back to guessing target names,
+ * which may well be wrong. Make that failure visible.
+ */
+export function reportUnresolvedSymbolId(lookup: TypeLookupAssembly, symbolId: string) {
+  const key = `${lookup.assembly.name}:${symbolId}`;
+  if (REPORTED_UNRESOLVED_SYMBOL_IDS.has(key)) {
+    return;
+  }
+  REPORTED_UNRESOLVED_SYMBOL_IDS.add(key);
+  logging.warn(
+    `Could not resolve symbol id ${JSON.stringify(symbolId)} against the assembly of ${JSON.stringify(
+      lookup.assembly.name,
+    )}. Target language names for this symbol will be guessed and may be incorrect. ` +
+      `To fix this, rebuild ${JSON.stringify(
+        lookup.assembly.name,
+      )} with an up-to-date jsii compiler, or report the issue to the library maintainers.`,
+  );
 }
 
 function findPackageJsonLocation(currentPath: string): string | undefined {

--- a/src/jsii/jsii-utils.ts
+++ b/src/jsii/jsii-utils.ts
@@ -2,7 +2,7 @@ import * as spec from '@jsii/spec';
 import { symbolIdentifier } from 'jsii/common';
 import * as ts from 'typescript';
 
-import { findTypeLookupAssembly, TypeLookupAssembly } from './assemblies';
+import { findTypeLookupAssembly, reportUnresolvedSymbolId, resolveSymbolIdFqn, TypeLookupAssembly } from './assemblies';
 import { ObjectLiteralStruct } from './jsii-types';
 import { AstRenderer } from '../renderer';
 import { typeContainsUndefined } from '../typescript/types';
@@ -214,7 +214,7 @@ export function lookupJsiiSymbol(typeChecker: ts.TypeChecker, sym: ts.Symbol): J
                 sym,
                 fmap(sourceAssembly, (sa) => ({ assembly: sa.assembly })),
               ),
-              (symbolId) => sourceAssembly?.symbolIdMap[symbolId],
+              (symbolId) => fmap(sourceAssembly, (sa) => resolveSymbolIdFqn(sa, symbolId)),
             ) ?? sourceAssembly?.assembly.name,
           sourceAssembly: asm,
           symbolType: 'module',
@@ -244,15 +244,24 @@ export function lookupJsiiSymbol(typeChecker: ts.TypeChecker, sym: ts.Symbol): J
   }
 
   return fmap(/([^#]*)(#.*)?/.exec(symbolId), ([, typeSymbolId, memberFragment]) => {
+    const fqn = fmap(sourceAssembly, (sa) => resolveSymbolIdFqn(sa, typeSymbolId));
+    if (fqn === undefined) {
+      // The symbol lives in a package that demonstrably has a jsii assembly,
+      // yet we cannot resolve it. Warn user about guessed target names.
+      if (sourceAssembly) {
+        reportUnresolvedSymbolId(sourceAssembly, typeSymbolId);
+      }
+      return undefined;
+    }
+
     if (memberFragment) {
-      return fmap(sourceAssembly?.symbolIdMap[typeSymbolId], (fqn) => ({
+      return {
         fqn: `${fqn}${memberFragment}`,
         sourceAssembly,
         symbolType: 'member',
-      }));
+      } as JsiiSymbol;
     }
-
-    return fmap(sourceAssembly?.symbolIdMap[typeSymbolId], (fqn) => ({ fqn, sourceAssembly, symbolType: 'type' }));
+    return { fqn, sourceAssembly, symbolType: 'type' } as JsiiSymbol;
   });
 }
 

--- a/test/commands/extract.test.ts
+++ b/test/commands/extract.test.ts
@@ -614,6 +614,97 @@ describe('can find fqns via symbolId when ', () => {
       otherAssembly.cleanup();
     }
   });
+
+  test('there is no jsii.tsc in package.json (package uses jsii.tsconfig)', async () => {
+    const outDir = 'jsii-outDir';
+    const otherAssembly = createAssemblyWithDirectories(undefined, outDir);
+    try {
+      // Simulate a package that manages its own tsconfig.json (`jsii.tsconfig`):
+      // no `jsii.tsc` in package.json, and no tsconfig.json published to npm.
+      // The assembly still records `metadata.tscRootDir`, but make sure it does
+      // not record `metadata.tscOutDir` (newer compilers may write it, and this
+      // test must exercise the heuristic used for assemblies that lack it).
+      const packageJsonPath = path.join(otherAssembly.moduleDirectory, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      delete packageJson.jsii.tsc;
+      packageJson.jsii.tsconfig = 'tsconfig.json';
+      fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+      delete (otherAssembly.assembly.metadata as any)?.tscOutDir;
+      otherAssembly.updateAssembly();
+
+      const outputFile = path.join(otherAssembly.moduleDirectory, 'test.tabl.json');
+      await extract.extractSnippets([otherAssembly.moduleDirectory], {
+        cacheToFile: outputFile,
+        ...defaultExtractOptions,
+      });
+
+      const tablet = await LanguageTablet.fromFile(outputFile);
+      const tr = tablet.tryGetSnippet(tablet.snippetKeys[0]);
+      expect(tr?.fqnsReferenced()).toEqual(['my_assembly.ClassA']);
+    } finally {
+      otherAssembly.cleanup();
+    }
+  });
+
+  test('outDir is only recorded in assembly metadata (tscOutDir)', async () => {
+    const outDir = 'jsii-outDir';
+    const otherAssembly = createAssemblyWithDirectories(undefined, outDir);
+    try {
+      // Simulate a `jsii.tsconfig` package built by a jsii compiler that
+      // records `tscOutDir` in the assembly metadata (symmetric with
+      // `tscRootDir`): no `jsii.tsc` in package.json, but the assembly
+      // carries the exact outDir.
+      const packageJsonPath = path.join(otherAssembly.moduleDirectory, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      delete packageJson.jsii.tsc;
+      packageJson.jsii.tsconfig = 'tsconfig.json';
+      fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+      (otherAssembly.assembly.metadata as any).tscOutDir = outDir;
+      otherAssembly.updateAssembly();
+
+      const outputFile = path.join(otherAssembly.moduleDirectory, 'test.tabl.json');
+      await extract.extractSnippets([otherAssembly.moduleDirectory], {
+        cacheToFile: outputFile,
+        ...defaultExtractOptions,
+      });
+
+      const tablet = await LanguageTablet.fromFile(outputFile);
+      const tr = tablet.tryGetSnippet(tablet.snippetKeys[0]);
+      expect(tr?.fqnsReferenced()).toEqual(['my_assembly.ClassA']);
+    } finally {
+      otherAssembly.cleanup();
+    }
+  });
+
+  test('warns when the symbol id cannot be resolved at all', async () => {
+    const outDir = 'jsii-outDir';
+    const otherAssembly = createAssemblyWithDirectories(undefined, outDir);
+    const warningSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // Remove every source of outDir/rootDir information: resolution is now impossible
+      const packageJsonPath = path.join(otherAssembly.moduleDirectory, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      delete packageJson.jsii.tsc;
+      fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+      delete (otherAssembly.assembly.metadata as any)?.tscRootDir;
+      delete (otherAssembly.assembly.metadata as any)?.tscOutDir;
+      otherAssembly.updateAssembly();
+
+      // Translate in-process so we can observe the warning
+      otherAssembly.translateHere(`
+        import { ClassA } from 'my_assembly';
+        new ClassA();
+      `);
+
+      expect(warningSpy).toHaveBeenCalledWith(expect.stringContaining('Could not resolve symbol id'));
+    } finally {
+      warningSpy.mockRestore();
+      otherAssembly.cleanup();
+    }
+  });
 });
 
 test('extract and infuse in one command', async () => {


### PR DESCRIPTION
Rosetta decides whether a symbol in a code sample is a jsii type by computing a symbol id from the TypeScript source and looking it up in the library's assembly. The two sides of that lookup are built from different paths: the assembly records symbol ids relative to the library's source root (e.g. `src/construct:Construct`), while Rosetta computes them from the shipped `.d.ts` files (e.g. `lib/construct:Construct`). Bridging the two requires knowing the library's TypeScript output directory, which Rosetta so far only read from `jsii.tsc.outDir` in the library's `package.json`.

Libraries that manage their own `tsconfig.json` (via `jsii.tsconfig`) don't have that key, and their `tsconfig.json` is usually not published to npm. For those libraries every lookup misses, Rosetta concludes the type isn't a jsii type at all, and silently falls back to deriving target language names from the npm package name. The result is plausible-looking but wrong output: with `constructs@10.8.0` (which recently adopted `jsii.tsconfig`), Java samples say `import constructs.Construct;` instead of `import software.constructs.Construct;`, and Go samples point at a made-up module path. Python and C# only escape by coincidence, because the guessed names happen to match the real ones.

This change makes the lookup resilient. When the assembly records the output directory in its metadata (`tscOutDir`, which up-to-date jsii compilers will write, see aws/jsii-compiler#2745), Rosetta re-roots the path exactly. For assemblies that predate that — including `constructs@10.8.0` as published today — it reconstructs the source path from the root directory the assembly does record, validating candidates against the assembly's own symbol id table so it never invents a mapping. The fix therefore works for already-published libraries, without waiting for them to be rebuilt.

Finally, if a symbol clearly belongs to a jsii package but still can't be resolved, Rosetta now prints a warning telling the user their generated names may be wrong and what they can do about it, rather than degrading silently. Silent plausible-but-wrong output is what let this bug ship in the first place.

Fixes the Rosetta side of aws/constructs#2879.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
