### PR TITLE
fix: non-compiling class renderings in the C# and Go visitors

### DIFF
--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -77,7 +77,7 @@ export class CSharpVisitor extends DefaultVisitor<CSharpLanguageContext> {
    * Bump this when you change something in the implementation to invalidate
    * existing cached translations.
    */
-  public static readonly VERSION = '1';
+  public static readonly VERSION = '2';
 
   public readonly language = TargetLanguage.CSHARP;
 
@@ -340,12 +340,35 @@ export class CSharpVisitor extends DefaultVisitor<CSharpLanguageContext> {
 
     // Suppress the LHS of the dot operator if it's "this." (not necessary in C#)
     // or if it's an imported module reference (C# has namespace-wide imports).
+    // Exception: keep "this." when the member, as it will be rendered, is
+    // shadowed by a parameter of an enclosing function. This matters for
+    // private fields (which keep their camelCase name): in a constructor
+    // assigning a same-named field, dropping the qualifier degrades
+    // `this.resource = resource` into the self-assignment `resource = resource;`.
+    const dropThis = lhs === 'this' && !this.memberShadowedByParameter(node, renderer);
     const objectExpression =
-      lhs === 'this' || this.dropPropertyAccesses.has(lhs)
+      dropThis || this.dropPropertyAccesses.has(lhs)
         ? []
         : [renderer.updateContext({ propertyOrMethod: false }).convert(node.expression), '.'];
 
     return new OTree([...objectExpression, renderer.updateContext({ propertyOrMethod: true }).convert(node.name)]);
+  }
+
+  private memberShadowedByParameter(node: ts.PropertyAccessExpression, renderer: CSharpRenderer): boolean {
+    const text = node.name.text;
+    // The name the member will render as: private properties keep their
+    // camelCase name, everything else is PascalCased (see `identifier`).
+    const renderedName = renderer.currentContext.privatePropertyNames.includes(text) ? text : ucFirst(text);
+
+    for (let current: ts.Node | undefined = node.parent; current != null; current = current.parent) {
+      if (
+        ts.isFunctionLike(current) &&
+        current.parameters.some((p) => ts.isIdentifier(p.name) && p.name.text === renderedName)
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public override parameterDeclaration(node: ts.ParameterDeclaration, renderer: CSharpRenderer): OTree {

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -631,20 +631,23 @@ export class GoVisitor extends DefaultVisitor<GoLanguageContext> {
   public override binaryExpression(node: ts.BinaryExpression, renderer: AstRenderer<GoLanguageContext>): OTree {
     if (node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
       const symbol = symbolFor(renderer.typeChecker, node.left);
-      // Parameters and properties are pointer-valued: a pointer-valued RHS
-      // must not be dereferenced (isPtrAssignmentRValue), and a literal RHS
-      // must be wrapped (wrapPtr) — `this.env = "production"` needs
-      // `jsii.String("production")`, not a raw literal.
-      const pointerTarget =
-        symbol?.valueDeclaration != null &&
-        (ts.isParameter(symbol.valueDeclaration) || ts.isPropertyDeclaration(symbol.valueDeclaration));
+      // What the right-hand side must be follows from how the left-hand side
+      // *renders*, and that differs between the two pointer-valued
+      // declarations. A property renders as the pointer field itself
+      // (`this.env`), so the RHS has to be a pointer: leave a pointer
+      // undereferenced, and wrap a literal — `this.env = "production"` needs
+      // `jsii.String("production")`. A parameter renders dereferenced (`*name`,
+      // see goName at the bottom of this file), so the target is a value and
+      // the RHS has to be one too — exactly the opposite of a property.
+      const target = symbol?.valueDeclaration;
+      const targetRendersAsPointer = target != null && ts.isPropertyDeclaration(target);
       return new OTree([
         renderer.convert(node.left),
         ' = ',
         renderer
           .updateContext({
-            isPtrAssignmentRValue: pointerTarget,
-            wrapPtr: pointerTarget || renderer.currentContext.wrapPtr,
+            isPtrAssignmentRValue: targetRendersAsPointer,
+            wrapPtr: targetRendersAsPointer,
           })
           .convert(node.right),
       ]);

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -82,7 +82,7 @@ export class GoVisitor extends DefaultVisitor<GoLanguageContext> {
    * Bump this when you change something in the implementation to invalidate
    * existing cached translations.
    */
-  public static readonly VERSION = '1';
+  public static readonly VERSION = '2';
 
   public readonly indentChar = '\t';
 
@@ -191,11 +191,13 @@ export class GoVisitor extends DefaultVisitor<GoLanguageContext> {
   }
 
   public override newExpression(node: ts.NewExpression, renderer: GoRenderer): OTree {
-    const { classNamespace, className } = determineClassName.call(this, node.expression);
+    const { classNamespace, className, unexported } = determineClassName.call(this, node.expression);
     return new OTree(
       [
         ...(classNamespace ? [classNamespace, '.'] : []),
-        'New', // Should this be "new" if the class is unexported?
+        // Constructors of unexported (snippet-local) classes render unexported
+        // (see constructorDeclaration) — the call site must match.
+        unexported ? 'new' : 'New',
         className,
         '(',
       ],
@@ -203,7 +205,10 @@ export class GoVisitor extends DefaultVisitor<GoLanguageContext> {
       { canBreakLine: true, separator: ', ', suffix: ')' },
     );
 
-    function determineClassName(this: GoVisitor, expr: ts.Expression): { classNamespace?: OTree; className: string } {
+    function determineClassName(
+      this: GoVisitor,
+      expr: ts.Expression,
+    ): { classNamespace?: OTree; className: string; unexported?: boolean } {
       if (ts.isIdentifier(expr)) {
         // Imported names are referred to by the original (i.e: exported) name, qualified with the source module's go
         // package name.
@@ -225,7 +230,18 @@ export class GoVisitor extends DefaultVisitor<GoLanguageContext> {
           };
         }
 
-        return { className: ucFirst(expr.text) };
+        // A snippet-local class renders an unexported constructor. Classes
+        // that model library types (jsii-resolvable, incl. 'fake-from-jsii'
+        // test fixtures) keep the exported naming even when declared
+        // unexported in the snippet.
+        const classDeclaration = symbol?.declarations?.find(ts.isClassDeclaration);
+        return {
+          className: ucFirst(expr.text),
+          unexported:
+            classDeclaration != null &&
+            !isExported(classDeclaration) &&
+            lookupJsiiSymbolFromNode(renderer.typeChecker, expr) == null,
+        };
       }
       if (ts.isPropertyAccessExpression(expr)) {
         if (ts.isIdentifier(expr.expression)) {
@@ -615,14 +631,20 @@ export class GoVisitor extends DefaultVisitor<GoLanguageContext> {
   public override binaryExpression(node: ts.BinaryExpression, renderer: AstRenderer<GoLanguageContext>): OTree {
     if (node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
       const symbol = symbolFor(renderer.typeChecker, node.left);
+      // Parameters and properties are pointer-valued: a pointer-valued RHS
+      // must not be dereferenced (isPtrAssignmentRValue), and a literal RHS
+      // must be wrapped (wrapPtr) — `this.env = "production"` needs
+      // `jsii.String("production")`, not a raw literal.
+      const pointerTarget =
+        symbol?.valueDeclaration != null &&
+        (ts.isParameter(symbol.valueDeclaration) || ts.isPropertyDeclaration(symbol.valueDeclaration));
       return new OTree([
         renderer.convert(node.left),
         ' = ',
         renderer
           .updateContext({
-            isPtrAssignmentRValue:
-              symbol?.valueDeclaration &&
-              (ts.isParameter(symbol.valueDeclaration) || ts.isPropertyDeclaration(symbol.valueDeclaration)),
+            isPtrAssignmentRValue: pointerTarget,
+            wrapPtr: pointerTarget || renderer.currentContext.wrapPtr,
           })
           .convert(node.right),
       ]);

--- a/test/translations/classes/constructor_parameter_shadows_field.cs
+++ b/test/translations/classes/constructor_parameter_shadows_field.cs
@@ -1,0 +1,18 @@
+class MyResource
+{
+    public string Env { get; }
+    private readonly string resource;
+
+    public MyResource(string resource)
+    {
+        this.resource = resource;
+        Env = "production";
+    }
+
+    public string Description()
+    {
+        return resource;
+    }
+}
+
+var r = new MyResource("bucket");

--- a/test/translations/classes/constructor_parameter_shadows_field.go
+++ b/test/translations/classes/constructor_parameter_shadows_field.go
@@ -1,0 +1,17 @@
+type myResource struct {
+	env *string
+	resource *string
+}
+
+func newMyResource(resource *string) *myResource {
+	this := &myResource{}
+	this.resource = resource
+	this.env = jsii.String("production")
+	return this
+}
+
+func (this *myResource) description() *string {
+	return this.resource
+}
+
+r := newMyResource(jsii.String("bucket"))

--- a/test/translations/classes/constructor_parameter_shadows_field.java
+++ b/test/translations/classes/constructor_parameter_shadows_field.java
@@ -1,0 +1,15 @@
+public class MyResource {
+    public final String env;
+    private final String resource;
+
+    public MyResource(String resource) {
+        this.resource = resource;
+        this.env = "production";
+    }
+
+    public String description() {
+        return this.resource;
+    }
+}
+
+MyResource r = new MyResource("bucket");

--- a/test/translations/classes/constructor_parameter_shadows_field.py
+++ b/test/translations/classes/constructor_parameter_shadows_field.py
@@ -1,0 +1,10 @@
+class MyResource:
+
+    def __init__(self, resource):
+        self.resource = resource
+        self.env = "production"
+
+    def description(self):
+        return self.resource
+
+r = MyResource("bucket")

--- a/test/translations/classes/constructor_parameter_shadows_field.ts
+++ b/test/translations/classes/constructor_parameter_shadows_field.ts
@@ -1,0 +1,15 @@
+class MyResource {
+  public readonly env: string;
+  private readonly resource: string;
+
+  constructor(resource: string) {
+    this.resource = resource;
+    this.env = 'production';
+  }
+
+  public description(): string {
+    return this.resource;
+  }
+}
+
+const r = new MyResource('bucket');

--- a/test/translations/expressions/assignment_to_parameter.cs
+++ b/test/translations/expressions/assignment_to_parameter.cs
@@ -1,0 +1,13 @@
+public string Normalize(string value, string fallback, int retries)
+{
+    if (!value)
+    {
+        value = fallback;
+    }
+    if (!fallback)
+    {
+        value = "anonymous";
+        retries = 3;
+    }
+    return value;
+}

--- a/test/translations/expressions/assignment_to_parameter.go
+++ b/test/translations/expressions/assignment_to_parameter.go
@@ -1,0 +1,10 @@
+func normalize(value *string, fallback *string, retries *f64) *string {
+	if !*value {
+		*value = *fallback
+	}
+	if !*fallback {
+		*value = "anonymous"
+		*retries = 3
+	}
+	return *value
+}

--- a/test/translations/expressions/assignment_to_parameter.java
+++ b/test/translations/expressions/assignment_to_parameter.java
@@ -1,0 +1,10 @@
+public String normalize(String value, String fallback, Number retries) {
+    if (!value) {
+        value = fallback;
+    }
+    if (!fallback) {
+        value = "anonymous";
+        retries = 3;
+    }
+    return value;
+}

--- a/test/translations/expressions/assignment_to_parameter.py
+++ b/test/translations/expressions/assignment_to_parameter.py
@@ -1,0 +1,7 @@
+def normalize(value, fallback, retries):
+    if not value:
+        value = fallback
+    if not fallback:
+        value = "anonymous"
+        retries = 3
+    return value

--- a/test/translations/expressions/assignment_to_parameter.ts
+++ b/test/translations/expressions/assignment_to_parameter.ts
@@ -1,0 +1,10 @@
+function normalize(value: string, fallback: string, retries: number): string {
+  if (!value) {
+    value = fallback;
+  }
+  if (!fallback) {
+    value = 'anonymous';
+    retries = 3;
+  }
+  return value;
+}


### PR DESCRIPTION
Fixes #3772.

Renderer bugs exposed while investigating aws/aws-cdk#38452: rewriting the `aws-s3`/`aws-kms` README example as a named class (the doc-side fix, aws/aws-cdk#38461) showed the C# and Go visitors emit non-compiling output for ordinary class shapes.

### C#: dropped `this.` produces a self-assignment

`propertyAccessExpression` suppressed `this.` unconditionally. Public members are PascalCased and can never collide with a camelCase parameter, but private fields keep their camelCase name — so a constructor assigning a same-named field rendered:

```csharp
public MyResource(string resource)
{
    resource = resource;   // CS1717 — the field is never assigned
}
```

The qualifier is now kept exactly when the member's *rendered* name (via the existing `privatePropertyNames` context — the same mechanism that decides casing) matches a parameter of an enclosing function:

```csharp
this.resource = resource;
```

All other output is unchanged — PascalCased members still drop `this.`.

### Go: constructor naming mismatch

`newExpression` hardcoded the `New` prefix (the code carried `// Should this be "new" if the class is unexported?`) while `constructorDeclaration` renders `new` for unexported classes — so a snippet-local class defined `func newMyResource` but was called as the non-existent `NewMyResource`. The call site now resolves the class identifier and matches the declaration. Classes that model library types (jsii-resolvable, including `/// fake-from-jsii` test fixtures) keep the exported call form, since only their call sites render — verified against the 6 existing corpus snippets that rely on this.

### Go: assignment wrapped the wrong side of the pointer

Parameters and properties are both pointer-valued in Go, but they do not *render* alike, and what the right-hand side has to be follows the rendering rather than the declaration:

- a **property** renders as the pointer field itself — `this.env`, a `*string`;
- a **parameter** renders dereferenced — `*name`, a `string` (the identifier rule at the bottom of `go.ts`).

So a property target wants a pointer on the right (leave a pointer alone, wrap a literal) and a parameter target wants a value (dereference a pointer, leave a literal raw) — opposite rules. The visitor set `isPtrAssignmentRValue` for both kinds and wrapped for neither, which broke each of them in one direction:

| TypeScript | rendered | why it fails |
| --- | --- | --- |
| `this.env = 'production'` | `this.env = "production"` | `*string = string` |
| `next = other` (both parameters) | `*next = other` | `string = *string` |

Both flags now key off whether the *target* renders as a pointer, which only a property does:

| TypeScript | rendered |
| --- | --- |
| `this.env = 'production'` | `this.env = jsii.String("production")` |
| `this.env = env` | `this.env = env` |
| `name = 'fallback'` | `*name = "fallback"` |
| `next = other` | `*next = *other` |

> **Review follow-up.** The first version of this change keyed off the declaration kind, and so wrapped literals for parameter targets too — producing `*name = jsii.String("fallback")`, the same mismatch in the opposite direction. Thanks @dgandhi62 for catching it. Corrected in 58de1d93, which also picks up the parameter-to-parameter case (`*next = other`) that the corrected rule covers and that was broken before this PR as well.

### Testing

Developed test-first, with two translations-corpus snippets carrying expectations for **all four languages** — Python, Java and C# pinned at their existing output, so the diff itself shows each change is confined to its own target:

- `classes/constructor_parameter_shadows_field` — the C# `this.` fix and the Go constructor naming fix;
- `expressions/assignment_to_parameter` — a parameter assigned from another parameter, from a string literal and from a number literal.

Each was run red before the corresponding change. Full suite passes: 25 suites, 549 tests, 6 pre-existing skips (corpus files that predate this PR and lack an expectation for one language). `CSharpVisitor.VERSION` and `GoVisitor.VERSION` are bumped to invalidate cached translations.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
